### PR TITLE
ZipFileConsumer for processing zipfiles

### DIFF
--- a/consume-redis-events.py
+++ b/consume-redis-events.py
@@ -58,6 +58,15 @@ def initialize_logger(debug_mode=False):
     logger.addHandler(console)
 
 
+def get_consumer(consumer_type, **kwargs):
+    ct = str(consumer_type).lower()
+    if ct == 'image':
+        return consumers.ImageFileConsumer(**kwargs)
+    if ct == 'zip':
+        return consumers.ZipFileConsumer(**kwargs)
+    raise ValueError('Invalid `consumer_type`: "{}"'.format(consumer_type))
+
+
 if __name__ == '__main__':
     initialize_logger(settings.DEBUG)
 
@@ -71,10 +80,13 @@ if __name__ == '__main__':
 
     storage_client = storage.get_client(settings.CLOUD_PROVIDER)
 
-    consumer = consumers.PredictionConsumer(
-        redis_client=redis,
-        storage_client=storage_client,
-        final_status='done')
+    kwargs = {
+        'redis_client': redis,
+        'storage_client': storage_client,
+        'final_status': 'done'
+    }
+
+    consumer = get_consumer(settings.CONSUMER_TYPE, **kwargs)
 
     while True:
         try:

--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -28,11 +28,11 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from time import time
 from timeit import default_timer
 
 import os
 import json
-import time
 import hashlib
 import logging
 
@@ -395,7 +395,7 @@ class ZipFileConsumer(Consumer):
                 new_hash = '{prefix}_{file}_{hash}'.format(
                     prefix=settings.HASH_PREFIX,
                     file=clean_imfile,
-                    hash=hashlib.md5('%s' % int(time.time())).hexdigest())
+                    hash=hashlib.md5(str(time()).encode('utf-8')).hexdigest())
 
                 new_hvals = dict()
                 new_hvals.update(hvalues)

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -41,6 +41,7 @@ DEBUG = config('DEBUG', cast=bool, default=False)
 
 # Consumer settings
 INTERVAL = config('INTERVAL', default=10, cast=int)
+CONSUMER_TYPE = config('CONSUMER_TYPE', default='image')
 
 # Hash Prefix - filter out prediction jobs
 HASH_PREFIX = _strip(config('HASH_PREFIX', cast=str, default='predict'))

--- a/tests/redis_consumer/test_consumers.py
+++ b/tests/redis_consumer/test_consumers.py
@@ -97,7 +97,7 @@ class DummyStorage(object):
         tiff.imsave(os.path.join(dest, path), img)
         return path
 
-    def upload(self, zip_path):  # pylint: disable=W0613
+    def upload(self, zip_path, subdir=None):  # pylint: disable=W0613
         return True
 
     def get_public_url(self, zip_path):  # pylint: disable=W0613

--- a/tests/redis_consumer/test_storage.py
+++ b/tests/redis_consumer/test_storage.py
@@ -91,6 +91,12 @@ class TestS3Storage(object):
                 dest = stg.upload(temp.name)
                 assert dest == 'output/{}'.format(os.path.basename(temp.name))
 
+                # test succesful upload with subdir
+                subdir = '/abc'
+                dest = stg.upload(temp.name, subdir=subdir)
+                assert dest == 'output{}/{}'.format(
+                    subdir, os.path.basename(temp.name))
+
                 # test failed upload
                 with pytest.raises(Exception):
                     # self._client raises, but so does storage.upload


### PR DESCRIPTION
Separate out the Image File processing and the Zip File processing work of the consumers into two separate classes, `ImageFileConsumer` and `ZipFileConsumer`.

ImageFileConsumers do the typical workload, but now will only process image files, and will ignore zipfiles.

ZipFileConsumers process .zip files and upload their image contents to the bucket for processing by ImageFileConsumers.