### PR TITLE
Hash Uploaded Files

### DIFF
--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -499,7 +499,7 @@ class ZipFileConsumer(Consumer):
                         # one of our hashes is done!
                         fname = self.redis.hget(h, 'file_name')
                         local_fname = self.storage.download(fname, tempdir)
-                        self.logger.info('saved file: %s', local_fname)
+                        self.logger.info('Saved file: %s', local_fname)
                         self.logger.info(fname)
                         saved_files.add(local_fname)
                         finished_hashes.add(h)


### PR DESCRIPTION
Ensure that each file that is downloaded is the most recently uploaded file, by hashing the filename with the current time, so that each filename is unique.  The original filename is maintained in Redis as `original_filename` so that zip files can be re-assembled with the original folder structure.

Fixes #22 