### PR TITLE
Pass `count` to `scan_iter` to limit size of results in memory

### DIFF
--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -77,7 +77,7 @@ class Consumer(object):  # pylint: disable=useless-object-inheritance
             Iterator of all hashes with a valid status
         """
         match = '%s*' % str(prefix).lower() if prefix is not None else None
-        for key in self.scan_iter(match=match):
+        for key in self.scan_iter(match=match, count=1000):
             # Check if the key is a hash
             if self._redis_type(key) == 'hash':
                 # if status is given, only yield hashes with that status
@@ -122,11 +122,11 @@ class Consumer(object):  # pylint: disable=useless-object-inheritance
                 time.sleep(self._redis_retry_timeout)
         return response
 
-    def scan_iter(self, match=None):
+    def scan_iter(self, match=None, count=None):
         while True:
             try:
                 start = timeit.default_timer()
-                response = self.redis.scan_iter(match=match)
+                response = self.redis.scan_iter(match=match, count=count)
                 self.logger.debug('Finished `SCAN %s` in %s seconds.',
                                   match, timeit.default_timer() - start)
                 break

--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -138,22 +138,6 @@ class Consumer(object):  # pylint: disable=useless-object-inheritance
                 time.sleep(self._redis_retry_timeout)
         return response
 
-    def keys(self):
-        while True:
-            try:
-                start = timeit.default_timer()
-                response = self.redis.keys()
-                self.logger.debug('KEYS got %s results in %s seconds.',
-                                  len(response), timeit.default_timer() - start)
-                break
-            except redis.exceptions.ConnectionError as err:
-                self.logger.warning('Encountered %s: %s when calling '
-                                    'KEYS. Retrying in %s seconds.',
-                                    type(err).__name__, err,
-                                    self._redis_retry_timeout)
-                time.sleep(self._redis_retry_timeout)
-        return response
-
     def hset(self, rhash, key, value):
         while True:
             try:

--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -112,10 +112,7 @@ class Consumer(object):  # pylint: disable=useless-object-inheritance
     def _redis_type(self, redis_key):
         while True:
             try:
-                # start = timeit.default_timer()
                 response = self.redis.type(redis_key)
-                # self.logger.debug('Finished `TYPE %s` in %s seconds.',
-                #                   redis_key, timeit.default_timer() - start)
                 break
             except redis.exceptions.ConnectionError as err:
                 self.logger.warning('Encountered %s: %s when calling '

--- a/redis_consumer/consumers_test.py
+++ b/redis_consumer/consumers_test.py
@@ -65,7 +65,7 @@ class DummyRedis(object):
             '{}_{}_{}'.format('other', self.status, 'x.zip'),
         ]
 
-    def scan_iter(self, match=None):
+    def scan_iter(self, match=None, count=None):
         if self.fail_count < self.fail_tolerance:
             self.fail_count += 1
             raise redis.exceptions.ConnectionError('thrown on purpose')

--- a/redis_consumer/consumers_test.py
+++ b/redis_consumer/consumers_test.py
@@ -169,14 +169,6 @@ class DummyStorage(object):
 
 class TestConsumer(object):
 
-    def test_keys(self):
-        redis_client = DummyRedis(fail_tolerance=2)
-        consumer = consumers.Consumer(redis_client, None,
-                                      redis_retry_timeout=0.01)
-        keys = consumer.keys()
-        assert keys == redis_client.keys()
-        assert consumer.redis.fail_count == redis_client.fail_tolerance
-
     def test_hgetall(self):
         redis_client = DummyRedis(fail_tolerance=2)
         consumer = consumers.Consumer(redis_client, None,


### PR DESCRIPTION
passing a default value of `count=1000` to `scan_iter` in order to improve memory performance.