### PR TITLE
Update ZipFileConsumer to expire hashes and track failures

### DIFF
--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -28,12 +28,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import uuid
-import timeit
-import datetime
 import os
 import json
 import time
+import uuid
+import urllib
+import timeit
+import datetime
 import logging
 import zipfile
 

--- a/redis_consumer/consumers_test.py
+++ b/redis_consumer/consumers_test.py
@@ -97,6 +97,9 @@ class DummyRedis(object):
     def hmset(self, rhash, hvals):  # pylint: disable=W0613
         return hvals
 
+    def expire(self, name, time):  # pylint: disable=W0613
+        return 1
+
     def hget(self, rhash, field):
         if field == 'status':
             return rhash.split('_')[1]

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -51,13 +51,13 @@ REDIS_HOST = config('REDIS_HOST', default='redis-master')
 REDIS_PORT = config('REDIS_PORT', default=6379, cast=int)
 
 # tensorflow-serving client connection
-TF_HOST = config('TF_HOST', default='tf-serving-service')
+TF_HOST = config('TF_HOST', default='tf-serving')
 TF_PORT = config('TF_PORT', default=8500, cast=int)
 TF_TENSOR_NAME = config('TF_TENSOR_NAME', default='image')
 TF_TENSOR_DTYPE = config('TF_TENSOR_DTYPE', default='DT_FLOAT')
 
 # data-processing client connection
-DP_HOST = config('DP_HOST', default='data-processing-service')
+DP_HOST = config('DP_HOST', default='data-processing')
 DP_PORT = config('DP_PORT', default=8080, cast=int)
 
 # gRPC API timeout in seconds (scales with `cuts`)


### PR DESCRIPTION
The `ZipFileConsumer` now expires each hash that it adds to Redis once it is completed or failed.  Additionally, each failed hash is stored inside a dictionary along with the failure reason.  These are then saved to the original zip hash so users can track the failures of each image.