### PR TITLE
Update `is_valid_hash` to ignore key prefix

### DIFF
--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -289,7 +289,7 @@ class ImageFileConsumer(Consumer):
                                         'seconds before retrying.',
                                         type(err).__name__, err.code().name,
                                         err.details(), key, process_type,
-                                        sleeptime)
+                                        backoff)
                     self.logger.debug('Waiting for %s seconds before retrying',
                                       backoff)
                     time.sleep(backoff)  # sleep before retry

--- a/redis_consumer/consumers_test.py
+++ b/redis_consumer/consumers_test.py
@@ -298,11 +298,11 @@ class TestImageFileConsumer(object):
         consumer = consumers.ImageFileConsumer(redis_client, storage, 'predict')
         assert consumer.is_valid_hash(None) is False
         assert consumer.is_valid_hash('file.ZIp') is False
-        assert consumer.is_valid_hash('predict:1234567890_file.ZIp') is False
-        assert consumer.is_valid_hash('track:123456789_file.zip') is False
-        assert consumer.is_valid_hash('predict:123456789_file.zip') is False
-        assert consumer.is_valid_hash('predict:1234567890_file.tiff') is True
-        assert consumer.is_valid_hash('predict:1234567890_file.png') is True
+        assert consumer.is_valid_hash('predict:1234567890:file.ZIp') is False
+        assert consumer.is_valid_hash('track:123456789:file.zip') is False
+        assert consumer.is_valid_hash('predict:123456789:file.zip') is False
+        assert consumer.is_valid_hash('predict:1234567890:file.tiff') is True
+        assert consumer.is_valid_hash('predict:1234567890:file.png') is True
 
     def test_process_big_image(self):
         name = 'model'
@@ -375,12 +375,12 @@ class TestZipFileConsumer(object):
 
         consumer = consumers.ZipFileConsumer(redis_client, storage, 'predict')
         assert consumer.is_valid_hash(None) is False
-        assert consumer.is_valid_hash('file.ZIp') is False
-        assert consumer.is_valid_hash('predict:1234567890_file.ZIp') is True
-        assert consumer.is_valid_hash('track:123456789_file.zip') is False
-        assert consumer.is_valid_hash('predict:123456789_file.zip') is True
-        assert consumer.is_valid_hash('predict:1234567890_file.tiff') is False
-        assert consumer.is_valid_hash('predict:1234567890_file.png') is False
+        assert consumer.is_valid_hash('file.ZIp') is True
+        assert consumer.is_valid_hash('predict:1234567890:file.ZIp') is True
+        assert consumer.is_valid_hash('track:123456789:file.zip') is True
+        assert consumer.is_valid_hash('predict:123456789:file.zip') is True
+        assert consumer.is_valid_hash('predict:1234567890:file.tiff') is False
+        assert consumer.is_valid_hash('predict:1234567890:file.png') is False
 
     def test__upload_archived_images(self):
         N = 3
@@ -473,14 +473,12 @@ class TestTrackingConsumer(object):
 
         consumer = consumers.TrackingConsumer(redis_client, storage, 'track')
         assert consumer.is_valid_hash(None) is False
-        assert consumer.is_valid_hash('file.ZIp') is False
-        assert consumer.is_valid_hash('predict:1234567890_file.ZIp') is False
-        assert consumer.is_valid_hash('predict:123456789_file.zip') is False
-        assert consumer.is_valid_hash('predict:1234567890_file.tiff') is False
-        assert consumer.is_valid_hash('predict:1234567890_file.png') is False
-        assert consumer.is_valid_hash('track:1234567890_file.ZIp') is False
-        assert consumer.is_valid_hash('track:123456789_file.zip') is False
-        assert consumer.is_valid_hash('track:1234567890_file.png') is False
-        assert consumer.is_valid_hash('track:1234567890_file.tiff') is True
-        assert consumer.is_valid_hash('track:1234567890_file.trk') is True
-        assert consumer.is_valid_hash('track:1234567890_file.trks') is True
+        assert consumer.is_valid_hash('predict:123456789:file.png') is False
+        assert consumer.is_valid_hash('predict:1234567890:file.tiff') is True
+        assert consumer.is_valid_hash('predict:1234567890:file.png') is False
+        assert consumer.is_valid_hash('track:1234567890:file.ZIp') is False
+        assert consumer.is_valid_hash('track:123456789:file.zip') is False
+        assert consumer.is_valid_hash('track:1234567890:file.png') is False
+        assert consumer.is_valid_hash('track:1234567890:file.tiff') is True
+        assert consumer.is_valid_hash('track:1234567890:file.trk') is True
+        assert consumer.is_valid_hash('track:1234567890:file.trks') is True

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -62,6 +62,7 @@ DP_PORT = config('DP_PORT', default=8080, cast=int)
 
 # gRPC API timeout in seconds (scales with `cuts`)
 GRPC_TIMEOUT = config('GRPC_TIMEOUT', default=30, cast=int)
+GRPC_BACKOFF = config('GRPC_BACKOFF', default=3, cast=int)
 # timeout/backoff wait time in seconds
 REDIS_TIMEOUT = config('REDIS_TIMEOUT', default=3, cast=int)
 EMPTY_QUEUE_TIMEOUT = config('EMPTY_QUEUE_TIMEOUT', default=5, cast=int)


### PR DESCRIPTION
No need to check the prefix of the key, as the key is already in the work queue.