### PR TITLE
all gRPC calls use a request_timeout of `GRPC_TIMEOUT`

### DIFF
--- a/consume-redis-events.py
+++ b/consume-redis-events.py
@@ -31,33 +31,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import sys
-import signal
-import traceback
 import logging
 import logging.handlers
+import sys
+import traceback
 
 import redis_consumer
 from redis_consumer import settings
-
-
-class GracefulDeath:
-    """Catch signals to allow graceful shutdown.
-
-    Adapted from: https://stackoverflow.com/questions/18499497
-    """
-
-    def __init__(self):
-        self.signum = None
-        self.kill_now = False
-        self.logger = logging.getLogger(str(self.__class__.__name__))
-        signal.signal(signal.SIGINT, self.handle_signal)
-        signal.signal(signal.SIGTERM, self.handle_signal)
-
-    def handle_signal(self, signum, frame):  # pylint: disable=unused-argument
-        self.signum = signum
-        self.kill_now = True
-        self.logger.debug('Received signal `%s` and frame `%s`', signum, frame)
 
 
 def initialize_logger(debug_mode=True):
@@ -82,7 +62,6 @@ def initialize_logger(debug_mode=True):
 
     logger.addHandler(console)
     logger.addHandler(fh)
-    logger.debug("Logger initialized.")
 
 
 def get_consumer(consumer_type, **kwargs):
@@ -99,7 +78,6 @@ def get_consumer(consumer_type, **kwargs):
 
 if __name__ == '__main__':
     initialize_logger(settings.DEBUG)
-    sighandler = GracefulDeath()
 
     _logger = logging.getLogger(__file__)
 
@@ -110,26 +88,22 @@ if __name__ == '__main__':
 
     storage_client = redis_consumer.storage.get_client(settings.CLOUD_PROVIDER)
 
-    kwargs = {
+    consumer_kwargs = {
         'redis_client': redis,
         'storage_client': storage_client,
         'final_status': 'done',
         'queue': settings.QUEUE,
     }
 
-    consumer = get_consumer(settings.CONSUMER_TYPE, **kwargs)
+    consumer = get_consumer(settings.CONSUMER_TYPE, **consumer_kwargs)
 
-    logging.debug('Got `%s` consumer.', settings.CONSUMER_TYPE)
+    _logger.debug('Got `%s` consumer.', settings.CONSUMER_TYPE)
 
     while True:
         try:
             consumer.consume()
-            if sighandler.kill_now:
-                break
         except Exception as err:  # pylint: disable=broad-except
             _logger.critical('Fatal Error: %s: %s\n%s',
                              type(err).__name__, err, traceback.format_exc())
 
             sys.exit(1)
-
-    _logger.info('Gracefully exited after signal number %s', sighandler.signum)

--- a/consume-redis-events.py
+++ b/consume-redis-events.py
@@ -86,9 +86,7 @@ def initialize_logger(debug_mode=True):
 
 
 def get_consumer(consumer_type, **kwargs):
-    logging.debug("Getting '{}' consumer with args {}.".format(
-        consumer_type,
-        kwargs))
+    logging.debug('Getting `%s` consumer with args %s.', consumer_type, kwargs)
     ct = str(consumer_type).lower()
     if ct == 'image':
         return redis_consumer.consumers.ImageFileConsumer(**kwargs)
@@ -121,7 +119,7 @@ if __name__ == '__main__':
 
     consumer = get_consumer(settings.CONSUMER_TYPE, **kwargs)
 
-    logging.debug("Got '{}' consumer.".format(settings.CONSUMER_TYPE))
+    logging.debug('Got `%s` consumer.', settings.CONSUMER_TYPE)
 
     while True:
         try:

--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -284,16 +284,15 @@ class ImageFileConsumer(Consumer):
                         'status': temp_status,
                         'process_retries': count,
                     })
-                    backoff = settings.GRPC_BACKOFF
                     self.logger.warning('%sException `%s: %s` during %s '
                                         '%s-processing request.  Waiting %s '
                                         'seconds before retrying.',
                                         type(err).__name__, err.code().name,
                                         err.details(), key, process_type,
-                                        backoff)
+                                        settings.GRPC_BACKOFF)
                     self.logger.debug('Waiting for %s seconds before retrying',
-                                      backoff)
-                    time.sleep(backoff)  # sleep before retry
+                                      settings.GRPC_BACKOFF)
+                    time.sleep(settings.GRPC_BACKOFF)  # sleep before retry
                     retrying = True  # Unneccessary but explicit
                 else:
                     retrying = False
@@ -393,7 +392,7 @@ class ImageFileConsumer(Consumer):
                           tf_results.shape, timeit.default_timer() - start)
         return tf_results
 
-    def grpc_image(self, img, model_name, model_version, timeout=30, backoff=3):
+    def grpc_image(self, img, model_name, model_version, timeout=30):
         count = 0
         start = timeit.default_timer()
         self.logger.debug('Segmenting image of shape %s with model %s:%s',
@@ -447,10 +446,10 @@ class ImageFileConsumer(Consumer):
                                         'Waiting %s seconds before retrying.',
                                         type(err).__name__, err.code().name,
                                         err.details(), model_name,
-                                        model_version, backoff)
+                                        model_version, settings.GRPC_BACKOFF)
                     self.logger.debug('Waiting for %s seconds before retrying',
-                                      backoff)
-                    time.sleep(backoff)  # sleep before retry
+                                      settings.GRPC_BACKOFF)
+                    time.sleep(settings.GRPC_BACKOFF)  # sleep before retry
                     retrying = True  # Unneccessary but explicit
                 else:
                     retrying = False
@@ -487,7 +486,6 @@ class ImageFileConsumer(Consumer):
             # configure timeout
             streaming = str(cuts).isdigit() and int(cuts) > 0
             timeout = settings.GRPC_TIMEOUT
-            backoff = settings.GRPC_BACKOFF
             timeout = timeout if not streaming else timeout * int(cuts)
 
             # Pre-process data before sending to the model
@@ -504,7 +502,7 @@ class ImageFileConsumer(Consumer):
                     cuts, image, field, model_name, model_version)
             else:
                 image = self.grpc_image(
-                    image, model_name, model_version, timeout, backoff)
+                    image, model_name, model_version, timeout)
 
             # Post-process model results
             self.update_key(redis_hash, {'status': 'post-processing'})

--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -206,14 +206,13 @@ class ImageFileConsumer(Consumer):
         fname = str(self.redis.hget(redis_hash, 'input_file_name'))
         return not fname.lower().endswith('.zip')
 
-    def _process(self, image, key, process_type, timeout=30, streaming=False):
+    def _process(self, image, key, process_type, streaming=False):
         """Apply each processing function to image.
 
         Args:
             image: numpy array of image data
             key: function to apply to image
             process_type: pre or post processing
-            timeout: integer. grpc request timeout.
             streaming: boolean. if True, streams data in multiple requests
 
         Returns:
@@ -249,9 +248,9 @@ class ImageFileConsumer(Consumer):
                              'data': np.expand_dims(image, axis=0)}]
 
                 if streaming:
-                    results = client.stream_process(req_data, timeout)
+                    results = client.stream_process(req_data, settings.GRPC_TIMEOUT)
                 else:
-                    results = client.process(req_data, timeout)
+                    results = client.process(req_data, settings.GRPC_TIMEOUT)
 
                 self.logger.debug('%s-processed key %s (model %s:%s, '
                                   'preprocessing: %s, postprocessing: %s)'
@@ -299,13 +298,12 @@ class ImageFileConsumer(Consumer):
                                   type(err).__name__, key, process_type, err)
                 raise err
 
-    def preprocess(self, image, keys, timeout=30, streaming=False):
+    def preprocess(self, image, keys, streaming=False):
         """Wrapper for _process_image but can only call with type="pre".
 
         Args:
             image: numpy array of image data
             keys: list of function names to apply to the image
-            timeout: integer. grpc request timeout.
             streaming: boolean. if True, streams data in multiple requests
 
         Returns:
@@ -314,16 +312,15 @@ class ImageFileConsumer(Consumer):
         pre = None
         for key in keys:
             x = pre if pre else image
-            pre = self._process(x, key, 'pre', timeout, streaming)
+            pre = self._process(x, key, 'pre', streaming)
         return pre
 
-    def postprocess(self, image, keys, timeout=30, streaming=False):
+    def postprocess(self, image, keys, streaming=False):
         """Wrapper for _process_image but can only call with type="post".
 
         Args:
             image: numpy array of image data
             keys: list of function names to apply to the image
-            timeout: integer. grpc request timeout.
             streaming: boolean. if True, streams data in multiple requests
 
         Returns:
@@ -332,7 +329,7 @@ class ImageFileConsumer(Consumer):
         post = None
         for key in keys:
             x = post if post else image
-            post = self._process(x, key, 'post', timeout, streaming)
+            post = self._process(x, key, 'post', streaming)
         return post
 
     def process_big_image(self,
@@ -388,7 +385,7 @@ class ImageFileConsumer(Consumer):
                           tf_results.shape, timeit.default_timer() - start)
         return tf_results
 
-    def grpc_image(self, img, model_name, model_version, timeout=30):
+    def grpc_image(self, img, model_name, model_version):
         count = 0
         start = timeit.default_timer()
         self.logger.debug('Segmenting image of shape %s with model %s:%s',
@@ -411,7 +408,7 @@ class ImageFileConsumer(Consumer):
                 self.logger.debug('Created the PredictClient in %s seconds.',
                                   timeit.default_timer() - t)
 
-                prediction = client.predict(req_data, request_timeout=timeout)
+                prediction = client.predict(req_data, settings.GRPC_TIMEOUT)
                 retrying = False
                 results = prediction['prediction']
                 self.logger.debug('Segmented key %s (model %s:%s, '
@@ -477,14 +474,12 @@ class ImageFileConsumer(Consumer):
 
             # configure timeout
             streaming = str(cuts).isdigit() and int(cuts) > 0
-            timeout = settings.GRPC_TIMEOUT
-            timeout = timeout if not streaming else timeout * int(cuts)
 
             # Pre-process data before sending to the model
             self.update_key(redis_hash, {'status': 'pre-processing'})
 
             pre_funcs = hvals.get('preprocess_function', '').split(',')
-            image = self.preprocess(image, pre_funcs, timeout, True)
+            image = self.preprocess(image, pre_funcs, True)
 
             # Send data to the model
             self.update_key(redis_hash, {'status': 'predicting'})
@@ -493,14 +488,13 @@ class ImageFileConsumer(Consumer):
                 image = self.process_big_image(
                     cuts, image, field, model_name, model_version)
             else:
-                image = self.grpc_image(
-                    image, model_name, model_version, timeout)
+                image = self.grpc_image(image, model_name, model_version)
 
             # Post-process model results
             self.update_key(redis_hash, {'status': 'post-processing'})
 
             post_funcs = hvals.get('postprocess_function', '').split(',')
-            image = self.postprocess(image, post_funcs, timeout, True)
+            image = self.postprocess(image, post_funcs, True)
 
             # Save the post-processed results to a file
             self.update_key(redis_hash, {'status': 'saving-results'})

--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -271,12 +271,8 @@ class ImageFileConsumer(Consumer):
                 retrying = False
                 return results
             except grpc.RpcError as err:
-                retry_statuses = {
-                    grpc.StatusCode.DEADLINE_EXCEEDED,
-                    grpc.StatusCode.UNAVAILABLE
-                }
                 # pylint: disable=E1101
-                if err.code() in retry_statuses:
+                if err.code() in settings.GRPC_RETRY_STATUSES:
                     count += 1
                     temp_status = 'retry-processing - {} - {}'.format(
                         count, err.code().name)
@@ -428,11 +424,7 @@ class ImageFileConsumer(Consumer):
                 return results
             except grpc.RpcError as err:
                 # pylint: disable=E1101
-                retry_statuses = {
-                    grpc.StatusCode.DEADLINE_EXCEEDED,
-                    grpc.StatusCode.UNAVAILABLE
-                }
-                if err.code() in retry_statuses:
+                if err.code() in settings.GRPC_RETRY_STATUSES:
                     count += 1
                     # write update to Redis
                     temp_status = 'retry-predicting - {} - {}'.format(

--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -472,7 +472,6 @@ class ImageFileConsumer(Consumer):
             fname = self.storage.download(hvals.get('input_file_name'), tempdir)
             image = utils.get_image(fname)
 
-            # configure timeout
             streaming = str(cuts).isdigit() and int(cuts) > 0
 
             # Pre-process data before sending to the model

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -30,6 +30,7 @@ from __future__ import print_function
 
 import os
 
+import grpc
 from decouple import config
 
 
@@ -63,6 +64,13 @@ DP_PORT = config('DP_PORT', default=8080, cast=int)
 # gRPC API timeout in seconds (scales with `cuts`)
 GRPC_TIMEOUT = config('GRPC_TIMEOUT', default=30, cast=int)
 GRPC_BACKOFF = config('GRPC_BACKOFF', default=3, cast=int)
+
+# Retry-able gRPC status codes
+GRPC_RETRY_STATUSES = {
+    grpc.StatusCode.DEADLINE_EXCEEDED,
+    grpc.StatusCode.UNAVAILABLE
+}
+
 # timeout/backoff wait time in seconds
 REDIS_TIMEOUT = config('REDIS_TIMEOUT', default=3, cast=int)
 EMPTY_QUEUE_TIMEOUT = config('EMPTY_QUEUE_TIMEOUT', default=5, cast=int)


### PR DESCRIPTION
Removed any fancy logic for gRPC timeouts and backoff times.  just directly use the value of the environment variable `GRPC_TIMEOUT`.

Also, removed GracefulDeath, as it did not resolve the problems it was added to solve.