### PR TITLE
Remove the streaming data processing requests and do the data processing directly

### DIFF
--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -341,10 +341,8 @@ class ImageFileConsumer(Consumer):
         f = self._get_processing_function(process_type, key)
         results = f(image)
 
-
         if results.shape[0] == 1:
             results = np.squeeze(results, axis=0)
-
 
         finished = timeit.default_timer() - start
 

--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -49,6 +49,7 @@ from redis_consumer.grpc_clients import ProcessClient
 from redis_consumer.grpc_clients import TrackingClient
 from redis_consumer import utils
 from redis_consumer import tracking
+from redis_consumer import processing
 from redis_consumer import settings
 
 
@@ -218,103 +219,119 @@ class ImageFileConsumer(Consumer):
         fname = str(self.redis.hget(redis_hash, 'input_file_name'))
         return not fname.lower().endswith('.zip')
 
-    def _process(self, image, key, process_type, streaming=False):
-        """Apply each processing function to image.
+    def _get_processing_function(self, process_type, function_name):
+        """Based on the function category and name, return the function"""
+        clean = lambda x: str(x).lower()
+        # first, verify the route parameters
+        name = clean(function_name)
+        cat = clean(process_type)
+        if cat not in settings.PROCESSING_FUNCTIONS:
+            raise ValueError('Processing functions are either "pre" or "post" '
+                             'processing.  Got %s.' % cat)
 
-        Args:
-            image: numpy array of image data
-            key: function to apply to image
-            process_type: pre or post processing
-            streaming: boolean. if True, streams data in multiple requests
+        if name not in settings.PROCESSING_FUNCTIONS[cat]:
+            if cat not in settings.PROCESSING_FUNCTIONS:
+                raise ValueError('"%s" is not a valid %s-processing function'
+                                 % (name, cat))
+        return settings.PROCESSING_FUNCTIONS[cat][name]
 
-        Returns:
-            list of processed image data
-        """
-        # Squeeze out batch dimension if unnecessary
-        if image.shape[0] == 1:
-            image = np.squeeze(image, axis=0)
-
-        if not key:
-            return image
-
-        self.logger.debug('Starting %s %s-processing image of shape %s',
-                          key, process_type, image.shape)
-
-        retrying = True
-        count = 0
-        start = timeit.default_timer()
-        while retrying:
-            try:
-                key = str(key).lower()
-                process_type = str(process_type).lower()
-                hostname = '{}:{}'.format(settings.DP_HOST, settings.DP_PORT)
-                client = ProcessClient(hostname, process_type, key)
-
-                if streaming:
-                    dtype = 'DT_STRING'
-                else:
-                    dtype = settings.TF_TENSOR_DTYPE
-
-                req_data = [{'in_tensor_name': settings.TF_TENSOR_NAME,
-                             'in_tensor_dtype': dtype,
-                             'data': np.expand_dims(image, axis=0)}]
-
-                if streaming:
-                    results = client.stream_process(req_data, settings.GRPC_TIMEOUT)
-                else:
-                    results = client.process(req_data, settings.GRPC_TIMEOUT)
-
-                finished = timeit.default_timer() - start
-
-                self.update_key(self._redis_hash, {
-                    '{}process_time'.format(process_type): finished
-                })
-
-                self.logger.debug('%s-processed key %s (model %s:%s, '
-                                  'preprocessing: %s, postprocessing: %s)'
-                                  ' (%s retries)  in %s seconds.',
-                                  process_type.capitalize(), self._redis_hash,
-                                  self._redis_values.get('model_name'),
-                                  self._redis_values.get('model_version'),
-                                  self._redis_values.get('preprocess_function'),
-                                  self._redis_values.get('postprocess_function'),
-                                  count, finished)
-
-                results = results['results']
-                # Again, squeeze out batch dimension if unnecessary
-                if results.shape[0] == 1:
-                    results = np.squeeze(results, axis=0)
-
-                retrying = False
-                return results
-            except grpc.RpcError as err:
-                # pylint: disable=E1101
-                if err.code() in settings.GRPC_RETRY_STATUSES:
-                    count += 1
-                    temp_status = 'retry-processing - {} - {}'.format(
-                        count, err.code().name)
-                    self.update_key(self._redis_hash, {
-                        'status': temp_status,
-                        'process_retries': count,
-                    })
-                    self.logger.warning('%sException `%s: %s` during %s '
-                                        '%s-processing request.  Waiting %s '
-                                        'seconds before retrying.',
-                                        type(err).__name__, err.code().name,
-                                        err.details(), key, process_type,
-                                        settings.GRPC_BACKOFF)
-                    self.logger.debug('Waiting for %s seconds before retrying',
-                                      settings.GRPC_BACKOFF)
-                    time.sleep(settings.GRPC_BACKOFF)  # sleep before retry
-                    retrying = True  # Unneccessary but explicit
-                else:
-                    retrying = False
-                    raise err
-            except Exception as err:
-                retrying = False
-                self.logger.error('Encountered %s during %s %s-processing: %s',
-                                  type(err).__name__, key, process_type, err)
-                raise err
+    # def _process(self, image, key, process_type, streaming=False):
+    #     """Apply each processing function to image.
+    #
+    #     Args:
+    #         image: numpy array of image data
+    #         key: function to apply to image
+    #         process_type: pre or post processing
+    #         streaming: boolean. if True, streams data in multiple requests
+    #
+    #     Returns:
+    #         list of processed image data
+    #     """
+    #     # Squeeze out batch dimension if unnecessary
+    #     if image.shape[0] == 1:
+    #         image = np.squeeze(image, axis=0)
+    #
+    #     if not key:
+    #         return image
+    #
+    #     self.logger.debug('Starting %s %s-processing image of shape %s',
+    #                       key, process_type, image.shape)
+    #
+    #     retrying = True
+    #     count = 0
+    #     start = timeit.default_timer()
+    #     while retrying:
+    #         try:
+    #             key = str(key).lower()
+    #             process_type = str(process_type).lower()
+    #             hostname = '{}:{}'.format(settings.DP_HOST, settings.DP_PORT)
+    #             client = ProcessClient(hostname, process_type, key)
+    #
+    #             if streaming:
+    #                 dtype = 'DT_STRING'
+    #             else:
+    #                 dtype = settings.TF_TENSOR_DTYPE
+    #
+    #             req_data = [{'in_tensor_name': settings.TF_TENSOR_NAME,
+    #                          'in_tensor_dtype': dtype,
+    #                          'data': np.expand_dims(image, axis=0)}]
+    #
+    #             if streaming:
+    #                 results = client.stream_process(req_data, settings.GRPC_TIMEOUT)
+    #             else:
+    #                 results = client.process(req_data, settings.GRPC_TIMEOUT)
+    #
+    #             finished = timeit.default_timer() - start
+    #
+    #             self.update_key(self._redis_hash, {
+    #                 '{}process_time'.format(process_type): finished
+    #             })
+    #
+    #             self.logger.debug('%s-processed key %s (model %s:%s, '
+    #                               'preprocessing: %s, postprocessing: %s)'
+    #                               ' (%s retries)  in %s seconds.',
+    #                               process_type.capitalize(), self._redis_hash,
+    #                               self._redis_values.get('model_name'),
+    #                               self._redis_values.get('model_version'),
+    #                               self._redis_values.get('preprocess_function'),
+    #                               self._redis_values.get('postprocess_function'),
+    #                               count, finished)
+    #
+    #             results = results['results']
+    #             # Again, squeeze out batch dimension if unnecessary
+    #             if results.shape[0] == 1:
+    #                 results = np.squeeze(results, axis=0)
+    #
+    #             retrying = False
+    #             return results
+    #         except grpc.RpcError as err:
+    #             # pylint: disable=E1101
+    #             if err.code() in settings.GRPC_RETRY_STATUSES:
+    #                 count += 1
+    #                 temp_status = 'retry-processing - {} - {}'.format(
+    #                     count, err.code().name)
+    #                 self.update_key(self._redis_hash, {
+    #                     'status': temp_status,
+    #                     'process_retries': count,
+    #                 })
+    #                 self.logger.warning('%sException `%s: %s` during %s '
+    #                                     '%s-processing request.  Waiting %s '
+    #                                     'seconds before retrying.',
+    #                                     type(err).__name__, err.code().name,
+    #                                     err.details(), key, process_type,
+    #                                     settings.GRPC_BACKOFF)
+    #                 self.logger.debug('Waiting for %s seconds before retrying',
+    #                                   settings.GRPC_BACKOFF)
+    #                 time.sleep(settings.GRPC_BACKOFF)  # sleep before retry
+    #                 retrying = True  # Unneccessary but explicit
+    #             else:
+    #                 retrying = False
+    #                 raise err
+    #         except Exception as err:
+    #             retrying = False
+    #             self.logger.error('Encountered %s during %s %s-processing: %s',
+    #                               type(err).__name__, key, process_type, err)
+    #             raise err
 
     def preprocess(self, image, keys, streaming=False):
         """Wrapper for _process_image but can only call with type="pre".
@@ -330,7 +347,9 @@ class ImageFileConsumer(Consumer):
         pre = None
         for key in keys:
             x = pre if pre else image
-            pre = self._process(x, key, 'pre', streaming)
+            # pre = self._process(x, key, 'pre', streaming)
+            f = self._get_processing_function('pre', key)
+            pre = f(x)
         return pre
 
     def postprocess(self, image, keys, streaming=False):
@@ -347,7 +366,9 @@ class ImageFileConsumer(Consumer):
         post = None
         for key in keys:
             x = post if post else image
-            post = self._process(x, key, 'post', streaming)
+            # post = self._process(x, key, 'post', streaming)
+            f = self._get_processing_function('post', key)
+            pre = f(x)
         return post
 
     def process_big_image(self,

--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -361,7 +361,7 @@ class ImageFileConsumer(Consumer):
 
         return results
 
-    def preprocess(self, image, keys):
+    def preprocess(self, image, keys, streaming=False):
         """Wrapper for _process_image but can only call with type="pre".
 
         Args:

--- a/redis_consumer/processing.py
+++ b/redis_consumer/processing.py
@@ -1,0 +1,176 @@
+# Copyright 2016-2019 The Van Valen Lab at the California Institute of
+# Technology (Caltech), with support from the Paul Allen Family Foundation,
+# Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
+# All rights reserved.
+#
+# Licensed under a modified Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.github.com/vanvalenlab/kiosk-redis-consumer/LICENSE
+#
+# The Work provided may be used for non-commercial academic purposes only.
+# For any other use of the Work, including commercial use, please contact:
+# vanvalenlab@gmail.com
+#
+# Neither the name of Caltech nor the names of its contributors may be used
+# to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Functions for pre- and post-processing image data"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+from scipy import ndimage
+from skimage import morphology
+from skimage.feature import peak_local_max
+from skimage.measure import label
+
+
+def noramlize(image):
+    """Normalize image data by dividing by the maximum pixel value
+
+    Args:
+        image: numpy array of image data
+
+    Returns:
+        normal_image: normalized image data
+    """
+    normal_image = (image - image.mean()) / image.std()
+    return normal_image
+
+
+def mibi(prediction, edge_threshold=.25, interior_threshold=.25):
+    """Post-processing for MIBI data. Uniquely segments every cell by
+    repeatedly eroding and dilating the cell interior prediction  until a
+    boundary is reached.
+
+    Args:
+        prediction: output from a deepcell transform (edge, interior, bg)
+        edge_threshold: confidence threshold to determine edge pixels
+        interior_threshold: confidence threshold to determine interior pixels
+
+    Returns:
+        transformed data where each cell is labeled uniquely
+    """
+
+    def dilate(array, mask, num_dilations):
+        copy = np.copy(array)
+        for _ in range(0, num_dilations):
+            dilated = morphology.dilation(copy)
+            # dilate if still in mask range not in another cell
+            copy = np.where((mask != 0) & (dilated != copy) & (copy == 0),
+                            dilated, copy)
+        return copy
+
+    def dilate_nomask(array, num_dilations):
+        copy = np.copy(array)
+        for _ in range(0, num_dilations):
+            dilated = morphology.dilation(copy)
+            # if one cell not eating another, dilate
+            copy = np.where((dilated != copy) & (copy == 0), dilated, copy)
+        return copy
+
+    def erode(array, num_erosions):
+        original = np.copy(array)
+        for _ in range(0, num_erosions):
+            eroded = morphology.erosion(np.copy(original))
+            original[original != eroded] = 0
+        return original
+
+    # edge = (prediction[..., 0] >= edge_threshold).astype('int')
+    edge = np.copy(prediction[..., 0])
+    edge[edge < edge_threshold] = 0
+    edge[edge >= edge_threshold] = 1
+
+    # interior = (prediction[..., 1] >= interior_threshold).astype('int')
+    interior = np.copy(prediction[..., 1])
+    interior[interior >= interior_threshold] = 1
+    interior[interior < interior_threshold] = 0
+
+    # define foreground as the interior bounded by edge
+    fg_thresh = np.logical_and(interior == 1, edge == 0)
+
+    # remove small objects from the foreground segmentation
+    fg_thresh = morphology.remove_small_objects(
+        fg_thresh, min_size=50, connectivity=1)
+
+    fg_thresh = np.expand_dims(fg_thresh, axis=-1)
+
+    segments = label(np.squeeze(fg_thresh), connectivity=2)
+
+    for _ in range(8):
+        segments = dilate(segments, interior, 2)
+        segments = erode(segments, 1)
+
+    segments = dilate(segments, interior, 2)
+
+    for _ in range(2):
+        segments = dilate_nomask(segments, 1)
+        segments = erode(segments, 2)
+
+    segments = np.expand_dims(segments, axis=-1)
+    return segments.astype('uint16')
+
+
+def watershed(image, min_distance=10, threshold_abs=0.05):
+    """Use the watershed method to identify unique cells based
+    on their distance transform.
+
+    # TODO: labels should be the fgbg output, NOT the union of distances
+
+    Args:
+        image: distance transform of image (model output)
+        min_distance: minimum number of pixels separating peaks
+        threshold_abs: minimum intensity of peaks
+
+    Returns:
+        image mask where each cell is annotated uniquely
+    """
+    distance = np.argmax(image, axis=-1)
+    labels = (distance > 0).astype('int')
+
+    local_maxi = peak_local_max(
+        image[..., -1],
+        min_distance=min_distance,
+        threshold_abs=threshold_abs,
+        indices=False,
+        labels=labels,
+        exclude_border=False)
+
+    # markers = label(local_maxi)
+    markers = ndimage.label(local_maxi)[0]
+    segments = morphology.watershed(-distance, markers, mask=labels)
+    results = np.expand_dims(segments, axis=-1)
+    results = morphology.remove_small_objects(
+        results, min_size=50, connectivity=1)
+    return results
+
+
+def deepcell(prediction, threshold=.8):
+    """Post-processing for deepcell transform predictions.
+    Uses the interior predictions to uniquely label every instance.
+
+    Args:
+        prediction: deepcell transform prediction
+        threshold: confidence threshold for interior predictions
+
+    Returns:
+        post-processed data with each cell uniquely annotated
+    """
+    if prediction.shape[0] == 1:
+        prediction = np.squeeze(prediction, axis=0)
+    interior = prediction[..., 2] > threshold
+    data = np.expand_dims(interior, axis=-1)
+    labeled = ndimage.label(data)[0]
+    labeled = morphology.remove_small_objects(
+        labeled, min_size=50, connectivity=1)
+    return labeled

--- a/redis_consumer/processing_test.py
+++ b/redis_consumer/processing_test.py
@@ -1,0 +1,69 @@
+# Copyright 2016-2019 The Van Valen Lab at the California Institute of
+# Technology (Caltech), with support from the Paul Allen Family Foundation,
+# Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
+# All rights reserved.
+#
+# Licensed under a modified Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.github.com/vanvalenlab/kiosk-redis-consumer/LICENSE
+#
+# The Work provided may be used for non-commercial academic purposes only.
+# For any other use of the Work, including commercial use, please contact:
+# vanvalenlab@gmail.com
+#
+# Neither the name of Caltech nor the names of its contributors may be used
+# to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Tests for post-processing functions"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+
+from redis_consumer import processing
+
+
+def _get_image(img_h=300, img_w=300):
+    bias = np.random.rand(img_w, img_h) * 64
+    variance = np.random.rand(img_w, img_h) * (255 - 64)
+    img = np.random.rand(img_w, img_h) * variance + bias
+    return img
+
+
+def test_normalize():
+    height, width = 300, 300
+    img = _get_image(height, width)
+    normalized_img = processing.noramlize(img)
+    np.testing.assert_almost_equal(normalized_img.mean(), 0)
+    np.testing.assert_almost_equal(normalized_img.var(), 1)
+
+
+def test_mibi():
+    channels = 3
+    img = np.random.rand(300, 300, channels)
+    mibi_img = processing.mibi(img)
+    np.testing.assert_equal(mibi_img.shape, (300, 300, 1))
+
+
+def test_deepcell():
+    channels = 4
+    img = np.random.rand(300, 300, channels)
+    deepcell_img = processing.deepcell(img)
+    np.testing.assert_equal(deepcell_img.shape, (300, 300, 1))
+
+
+def test_watershed():
+    channels = np.random.randint(4, 8)
+    img = np.random.rand(300, 300, channels)
+    watershed_img = processing.watershed(img)
+    np.testing.assert_equal(watershed_img.shape, (300, 300, 1))

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -33,6 +33,8 @@ import os
 import grpc
 from decouple import config
 
+from redis_consumer import processing
+
 
 # remove leading/trailing "/"s from cloud bucket folder names
 _strip = lambda x: '/'.join(y for y in x.split('/') if y)
@@ -107,3 +109,15 @@ HOSTNAME = config('HOSTNAME', default='host-unkonwn')
 
 # Redis queue
 QUEUE = config('QUEUE', default='predict')
+
+# Pre- and Post-processing settings
+PROCESSING_FUNCTIONS = {
+    'pre': {
+        'normalize': processing.noramlize,
+    },
+    'post': {
+        'deepcell': processing.deepcell,
+        'mibi': processing.mibi,
+        'watershed': processing.watershed
+    },
+}


### PR DESCRIPTION
Scaling the dataprocessing API has proven to be a significant bottleneck, and the seemingly obvious way to move forward is to do the data processing directly on the redis consumer.  This will remove the latency between tf-serving requests and hopefully speed up our performance significantly.

The data processing API could make a comeback in the future, but while it is being optimized, let's just do the work on the CPU we have.