### PR TITLE
Fixed bug for postprocess images and lists of images

### DIFF
--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -602,7 +602,10 @@ class ImageFileConsumer(Consumer):
             post_funcs = hvals.get('postprocess_function', '').split(',')
             # image[:-1] is targeted at a two semantic head panoptic model
             # TODO This may need to be modified and generalized in the future
-            image = self.postprocess(image[:-1], post_funcs, True)
+            if isinstance(image, list):
+                image = self.postprocess(image[:-1], post_funcs, True)
+            else:
+                image = self.postprocess(image, post_funcs, True)
 
             # Save the post-processed results to a file
             _ = timeit.default_timer()


### PR DESCRIPTION
A bug was introduced in #45 that sliced into the last element of the list of results to pass to the post-processing function.  This is only applicable for panoptic models, and caused a breaking change for single predictions.  There is still a `TODO` for not just picking out the last element of the results list, but now we check that `image` is in fact a list before slicing.