### PR TITLE
Enable scale and label type detection

### DIFF
--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -394,8 +394,9 @@ class TensorFlowServingConsumer(Consumer):
 
         # Reshape data to match size of data that model was trained on
         # TODO Generalize to support rectangular and other shapes
-        if (image.shape[1] >= settings.SCALE_RESHAPE_SIZE) and (image.shape[2] >= settings.SCALE_RESHAPE_SIZE):
-            image, _ = utils.reshape_matrix(image, image, reshape_size=settings.SCALE_RESHAPE_SIZE)
+        size = settings.SCALE_RESHAPE_SIZE
+        if (image.shape[1] >= size) and (image.shape[2] >= size):
+            image, _ = utils.reshape_matrix(image, image, reshape_size=size)
 
         model_name, model_version = settings.SCALE_DETECT_MODEL.split(':')
 
@@ -419,9 +420,9 @@ class TensorFlowServingConsumer(Consumer):
             image = np.expand_dims(image, axis=-1)
 
         # TODO Generalize to support rectangular and other shapes
-        if (image.shape[1] >= settings.LABEL_RESHAPE_SIZE) and \
-            (image.shape[2] >= settings.LABEL_RESHAPE_SIZE):
-            image, _ = utils.reshape_matrix(image, image, reshape_size=settings.LABEL_RESHAPE_SIZE)
+        size = settings.LABEL_RESHAPE_SIZE
+        if (image.shape[1] >= size) and (image.shape[2] >= size):
+            image, _ = utils.reshape_matrix(image, image, reshape_size=size)
 
         model_name, model_version = settings.LABEL_DETECT_MODEL.split(':')
 

--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -243,7 +243,7 @@ class TensorFlowServingConsumer(Consumer):
         hostname = '{}:{}'.format(settings.TF_HOST, settings.TF_PORT)
         client = PredictClient(hostname, model_name, int(model_version))
         self.logger.debug('Created the PredictClient in %s seconds.',
-                        timeit.default_timer() - t)
+                          timeit.default_timer() - t)
         return client
 
     def grpc_image(self, img, model_name, model_version):
@@ -365,7 +365,7 @@ class TensorFlowServingConsumer(Consumer):
             if tf_results is None:
                 tf_results = np.zeros(list(img.shape)[:-1] + [resp.shape[-1]])
                 self.logger.debug('Initialized output tensor of shape %s',
-                                tf_results.shape)
+                                  tf_results.shape)
 
             tf_results[..., a:b, c:d, :] = resp[..., winx:-winx, winy:-winy, :]
 
@@ -727,11 +727,11 @@ class ImageFileConsumer(TensorFlowServingConsumer):
                 outpaths = []
                 for i in image:
                     outpaths.extend(utils.save_numpy_array(
-                        utils.rescale(i, 1/scale), name=name,
+                        utils.rescale(i, 1 / scale), name=name,
                         subdir=subdir, output_dir=tempdir))
             else:
                 outpaths = utils.save_numpy_array(
-                    utils.rescale(image, 1/scale), name=name,
+                    utils.rescale(image, 1 / scale), name=name,
                     subdir=subdir, output_dir=tempdir)
 
             # Save each prediction image as zip file

--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -44,7 +44,6 @@ import numpy as np
 import pytz
 import skimage
 
-from redis_consumer.utils import reshape_matrix
 from redis_consumer.grpc_clients import PredictClient
 # from redis_consumer.grpc_clients import ProcessClient
 from redis_consumer.grpc_clients import TrackingClient
@@ -556,7 +555,7 @@ class ImageFileConsumer(Consumer):
     def detect_scale(self, image):
         start = timeit.default_timer()
         # Rescale image for compatibility with scale model
-        image, _ = reshape_matrix(np.expand_dims(image, axis=0), np.expand_dims(image, axis=0),
+        image, _ = utils.reshape_matrix(np.expand_dims(image, axis=0), np.expand_dims(image, axis=0),
                                   reshape_size=216)
 
         # Loop over each image in the batch dimension for scale prediction
@@ -610,7 +609,7 @@ class ImageFileConsumer(Consumer):
             else:
                 scale = float(scale)
                 self.logger.debug('Image scale already calculated: %s', scale)
-            image = skimage.transform.rescale(image, scale)
+            image = utils.rescale(image, scale)
 
             pre_funcs = hvals.get('preprocess_function', '').split(',')
             image = self.preprocess(image, pre_funcs, True)
@@ -649,11 +648,11 @@ class ImageFileConsumer(Consumer):
                 outpaths = []
                 for i in image:
                     outpaths.extend(utils.save_numpy_array(
-                        skimage.transform.rescale(i, 1/scale), name=name,
+                        utils.rescale(i, 1/scale), name=name,
                         subdir=subdir, output_dir=tempdir))
             else:
                 outpaths = utils.save_numpy_array(
-                    skimage.transform.rescale(image, 1/scale), name=name,
+                    utils.rescale(image, 1/scale), name=name,
                     subdir=subdir, output_dir=tempdir)
 
             # Save each prediction image as zip file
@@ -1027,7 +1026,7 @@ class TrackingConsumer(Consumer):
         # Rescale image for compatibility with scale model
         image = np.expand_dims(image, axis=-1)
         if (image.shape[1]>=216) and (image.shape[2]>=216):
-            image, _ = reshape_matrix(image, image, reshape_size=216)
+            image, _ = utils.reshape_matrix(image, image, reshape_size=216)
 
         # Loop over each image in the batch dimension for scale prediction
         Lscale = []

--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -243,7 +243,7 @@ class TensorFlowServingConsumer(Consumer):
         hostname = '{}:{}'.format(settings.TF_HOST, settings.TF_PORT)
         client = PredictClient(hostname, model_name, int(model_version))
         self.logger.debug('Created the PredictClient in %s seconds.',
-                            timeit.default_timer() - t)
+                        timeit.default_timer() - t)
         return client
 
     def grpc_image(self, img, model_name, model_version):
@@ -365,7 +365,7 @@ class TensorFlowServingConsumer(Consumer):
             if tf_results is None:
                 tf_results = np.zeros(list(img.shape)[:-1] + [resp.shape[-1]])
                 self.logger.debug('Initialized output tensor of shape %s',
-                                    tf_results.shape)
+                                tf_results.shape)
 
             tf_results[..., a:b, c:d, :] = resp[..., winx:-winx, winy:-winy, :]
 
@@ -417,6 +417,8 @@ class TensorFlowServingConsumer(Consumer):
 
     def _pick_model(self, label):
         # Identify appropriate model for label type
+        model_name, model_version = None, None
+
         if label == 0:
             model_name = settings.NUCLEAR_MODEL_NAME
             model_version = settings.NUCLEAR_MODEL_VERSION

--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -593,7 +593,8 @@ class ImageFileConsumer(Consumer):
                     settings.SCALE_DETECT_MODEL_VERSION)
             else:
                 scale = self.grpc_image(image, settings.SCALE_DETECT_MODEL_NAME,
-                    settings.SCALE_DETECT_MODEL_VERSION)
+                                        settings.SCALE_DETECT_MODEL_VERSION)
+            self.logger.debug('Image scale detected: %s %s', scale, scale.shape)
             image = skimage.transform.rescale(image, scale)
 
             pre_funcs = hvals.get('preprocess_function', '').split(',')
@@ -1013,6 +1014,14 @@ class TrackingConsumer(Consumer):
         self.logger.debug('Got tiffstack shape %s.', tiff_stack.shape)
         self.logger.debug('tiffstack num_frames %s.', num_frames)
 
+        # TODO Calculate scale of stack and take average of value predicted for each frame
+        # self.scale =
+        # TODO Rescale stack
+        # TODO Set redis hash value
+
+        # TODO Predict label type of stack, take vote
+        # TODO set redis hash value
+
         with utils.get_tempdir() as tempdir:
             for (i, img) in enumerate(tiff_stack):
                 # make a file name for this frame
@@ -1026,7 +1035,6 @@ class TrackingConsumer(Consumer):
                     segment_local_path)
 
                 # prepare hvalues for this frame's hash
-                # TODO: model info should not be hardcoded
                 current_timestamp = self.get_current_timestamp()
                 frame_hvalues = {
                     'identity_upload': self.hostname,
@@ -1135,6 +1143,9 @@ class TrackingConsumer(Consumer):
             tracker._track_cells()
 
             self.logger.debug('Tracking done!')
+
+            # TODO Rescale data back to original size
+            # Use self.scale value set in self.load_data
 
             # Save tracking result and upload
             save_name = os.path.join(

--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -669,7 +669,7 @@ class ImageFileConsumer(TensorFlowServingConsumer):
             })
 
             # Calculate scale of image and rescale
-            scale = hvals.get('scale', None)
+            scale = hvals.get('scale')
             if scale is None:
                 # Detect scale of image
                 scale = self.detect_scale(image)
@@ -682,7 +682,7 @@ class ImageFileConsumer(TensorFlowServingConsumer):
             image = utils.rescale(image, scale)
 
             # Detect image label type
-            label = hvals.get('label', None)
+            label = hvals.get('label')
             if label is None:
                 label = self.detect_label(image)
                 self.logger.debug('Image label detected: %s', label)

--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -1179,7 +1179,7 @@ class TrackingConsumer(TensorFlowServingConsumer):
             model_name, model_version = utils._pick_model(label)
             postprocess_function = utils._pick_postprocess(label)
         else:
-            label = 99 # Equivalent to none
+            label = 99  # Equivalent to none
             model_name, model_version = settings.TRACKING_SEGMENT_MODEL.split(':')
             postprocess_function = settings.TRACKING_POSTPROCESS_FUNCTION
 

--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -408,7 +408,8 @@ class TensorFlowServingConsumer(Consumer):
         for i in range(0, image.shape[0], settings.SCALE_DETECT_SAMPLE):
             scales.append(self.grpc_image(image[i], model_name, model_version))
 
-        self.logger.debug('Scale detection complete in %s seconds', timeit.default_timer() - start)
+        self.logger.debug('Scale detection complete in %s seconds',
+                          timeit.default_timer() - start)
         return np.mean(scales)
 
     def detect_label(self, image):
@@ -1172,10 +1173,9 @@ class TrackingConsumer(TensorFlowServingConsumer):
 
         # Pick model and postprocess based on either label or defaults
         if settings.LABEL_DETECT_ENABLED:
-            # Predict label type
-            label = self.detect_label(tiff_stack)
+            label = self.detect_label(tiff_stack)  # Predict label type
 
-            # Grap appropriate model and postprocess function
+            # Get appropriate model and postprocess function for the label
             model_name, model_version = utils._pick_model(label)
             postprocess_function = utils._pick_postprocess(label)
         else:

--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -1206,7 +1206,7 @@ class TrackingConsumer(Consumer):
 
         frames = [frames[i] for i in range(num_frames)]
 
-        return {"X": np.squeeze(raw, axis=-1), "y": np.array(frames)}
+        return {"X": np.expand_dims(tiff_stack, axis=-1), "y": np.array(frames)}
 
     def _consume(self, redis_hash):
         hvalues = self.redis.hgetall(redis_hash)

--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -390,6 +390,7 @@ class TensorFlowServingConsumer(Consumer):
             image = np.expand_dims(image, axis=0)
         else:
             image = np.expand_dims(image, axis=-1)
+
         if (image.shape[1] >= 216) and (image.shape[2] >= 216):
             image, _ = utils.reshape_matrix(image, image, reshape_size=216)
 
@@ -410,6 +411,7 @@ class TensorFlowServingConsumer(Consumer):
             image = np.expand_dims(image, axis=0)
         else:
             image = np.expand_dims(image, axis=-1)
+
         if (image.shape[1] >= 216) and (image.shape[2] >= 216):
             image, _ = utils.reshape_matrix(image, image, reshape_size=216)
 
@@ -424,7 +426,8 @@ class TensorFlowServingConsumer(Consumer):
         vote = labels.sum(axis=0)
         maj = vote.max()
 
-        self.logger.debug('Label detection complete %s seconds', timeit.default_timer() - start)
+        self.logger.debug('Label detection complete %s seconds.',
+                          timeit.default_timer() - start)
         return np.where(vote == maj)[-1][0]
 
 
@@ -675,6 +678,7 @@ class ImageFileConsumer(TensorFlowServingConsumer):
             else:
                 scale = float(scale)
                 self.logger.debug('Image scale already calculated: %s', scale)
+
             image = utils.rescale(image, scale)
 
             # Detect image label type
@@ -685,6 +689,7 @@ class ImageFileConsumer(TensorFlowServingConsumer):
                 self.update_key(redis_hash, {'label': str(label)})
             else:
                 self.logger.debug('Image label already calculated: %s', label)
+
             label = int(label)
 
             # Grap appropriate model

--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -420,7 +420,7 @@ class TensorFlowServingConsumer(Consumer):
         maj = vote.max()
 
         self.logger.debug('Label detection complete %s seconds', timeit.default_timer() - start)
-        return np.where(vote == maj)[0][0]
+        return np.where(vote == maj)[-1][0]
 
 
 class ImageFileConsumer(TensorFlowServingConsumer):

--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -1179,6 +1179,7 @@ class TrackingConsumer(TensorFlowServingConsumer):
             model_name, model_version = utils._pick_model(label)
             postprocess_function = utils._pick_postprocess(label)
         else:
+            label = 99 # Equivalent to none
             model_name, model_version = settings.TRACKING_SEGMENT_MODEL.split(':')
             postprocess_function = settings.TRACKING_POSTPROCESS_FUNCTION
 

--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -555,7 +555,7 @@ class ImageFileConsumer(Consumer):
     def detect_scale(self, image):
         start = timeit.default_timer()
         # Rescale image for compatibility with scale model
-        image = np.expand_dims(image, axis=-1)
+        image = np.expand_dims(image, axis=0)
         if (image.shape[1] >= 216) and (image.shape[2] >= 216):
             image, _ = utils.reshape_matrix(image, image, reshape_size=216)
 
@@ -571,7 +571,7 @@ class ImageFileConsumer(Consumer):
     def detect_label(self, image):
         start = timeit.default_timer()
         # Rescale for model compatibility
-        image = np.expand_dims(image, axis=-1)
+        image = np.expand_dims(image, axis=0)
         if (image.shape[1] >= 216) and (image.shape[2] >= 216):
             image, _ = utils.reshape_matrix(image, image, reshape_size=216)
 
@@ -638,9 +638,10 @@ class ImageFileConsumer(Consumer):
             if label is None:
                 label = self.detect_label(image)
                 self.logger.debug('Image label detected: %s', label)
-                self.update_key(redis_hash, {'label': label})
+                self.update_key(redis_hash, {'label': str(label)})
             else:
                 self.logger.debug('Image label already calculated: %s', label)
+            label = int(label)
 
             # Identify appropriate model for label type
             if label == 0:

--- a/redis_consumer/consumers_test.py
+++ b/redis_consumer/consumers_test.py
@@ -386,6 +386,24 @@ class TestTensorFlowServingConsumer(object):
         res = consumer.process_big_image(cuts, img, field, name, version)
         np.testing.assert_equal(res, img)
 
+    def test_detect_label(self):
+        redis_client = DummyRedis([])
+        consumer = consumers.TensorFlowServingConsumer(redis_client, None, 'q')
+        image = _get_image(settings.LABEL_RESHAPE_SIZE * 2,
+                           settings.LABEL_RESHAPE_SIZE * 2)
+
+        settings.LABEL_DETECT_MODEL = 'dummymodel:1'
+
+        def dummydata(*_, **__):
+            data = np.zeros((3,))
+            i = np.random.randint(3)
+            data[i] = 1
+            return data
+
+        consumer.grpc_image = dummydata
+
+        label = consumer.detect_label(image)
+        assert label in set(list(range(4)))
 
     def test_detect_scale(self):
         redis_client = DummyRedis([])

--- a/redis_consumer/consumers_test.py
+++ b/redis_consumer/consumers_test.py
@@ -442,6 +442,9 @@ class TestImageFileConsumer(object):
         def detect_scale(_):
             return 1
 
+        def detect_label(_):
+            return 0
+
         dummyhash = '{}:test.tiff:{}'.format(prefix, status)
 
         # consumer._handle_error = _handle_error
@@ -469,6 +472,7 @@ class TestImageFileConsumer(object):
         consumer = consumers.ImageFileConsumer(redis_client, storage, prefix)
         consumer._handle_error = _handle_error
         consumer.detect_scale = detect_scale
+        consumer.detect_label = detect_label
         consumer.grpc_image = grpc_image
         consumer._consume(dummyhash)
 
@@ -481,6 +485,7 @@ class TestImageFileConsumer(object):
         consumer = consumers.ImageFileConsumer(redis_client, storage, prefix)
         consumer._handle_error = _handle_error
         consumer.detect_scale = detect_scale
+        consumer.detect_label = detect_label
         consumer.grpc_image = grpc_image_list
         consumer._consume(dummyhash)
 

--- a/redis_consumer/consumers_test.py
+++ b/redis_consumer/consumers_test.py
@@ -387,6 +387,20 @@ class TestTensorFlowServingConsumer(object):
         np.testing.assert_equal(res, img)
 
 
+    def test_detect_scale(self):
+        redis_client = DummyRedis([])
+        consumer = consumers.TensorFlowServingConsumer(redis_client, None, 'q')
+        image = _get_image(settings.SCALE_RESHAPE_SIZE * 2,
+                           settings.SCALE_RESHAPE_SIZE * 2)
+
+        settings.SCALE_DETECT_MODEL = 'dummymodel:1'
+
+        consumer.grpc_image = lambda *x: np.random.randint(0, 1, shape=(1, 3))
+
+        scale = consumer.detect_scale(image)
+        assert isinstance(scale, (float, int))
+
+
 class TestImageFileConsumer(object):
 
     def test_is_valid_hash(self):

--- a/redis_consumer/consumers_test.py
+++ b/redis_consumer/consumers_test.py
@@ -430,6 +430,7 @@ class TestImageFileConsumer(object):
         status = 'new'
         redis_client = DummyRedis(prefix, status)
         storage = DummyStorage()
+
         consumer = consumers.ImageFileConsumer(redis_client, storage, prefix)
 
         def _handle_error(err, rhash):  # pylint: disable=W0613
@@ -438,10 +439,14 @@ class TestImageFileConsumer(object):
         def grpc_image_multi(data, *args, **kwargs):  # pylint: disable=W0613
             return np.array(tuple(list(data.shape) + [2]))
 
+        def detect_scale(_):
+            return 1
+
         dummyhash = '{}:test.tiff:{}'.format(prefix, status)
 
         # consumer._handle_error = _handle_error
         consumer.grpc_image = grpc_image_multi
+        consumer.detect_scale = detect_scale
         consumer._consume(dummyhash)
 
         # test mutli-channel
@@ -463,6 +468,7 @@ class TestImageFileConsumer(object):
         redis_client.hmset = lambda x, y: True
         consumer = consumers.ImageFileConsumer(redis_client, storage, prefix)
         consumer._handle_error = _handle_error
+        consumer.detect_scale = detect_scale
         consumer.grpc_image = grpc_image
         consumer._consume(dummyhash)
 
@@ -474,6 +480,7 @@ class TestImageFileConsumer(object):
         redis_client = DummyRedis(prefix, status)
         consumer = consumers.ImageFileConsumer(redis_client, storage, prefix)
         consumer._handle_error = _handle_error
+        consumer.detect_scale = detect_scale
         consumer.grpc_image = grpc_image_list
         consumer._consume(dummyhash)
 

--- a/redis_consumer/consumers_test.py
+++ b/redis_consumer/consumers_test.py
@@ -362,7 +362,7 @@ class TestTensorFlowServingConsumer(object):
         field = 11
         cuts = 2
 
-        img = np.expand_dims(_get_image(300, 300), axis=-1)
+        img = np.expand_dims(_get_image(100, 100), axis=-1)
         img = np.expand_dims(img, axis=0)
 
         redis_client = None

--- a/redis_consumer/processing.py
+++ b/redis_consumer/processing.py
@@ -36,6 +36,7 @@ from skimage.feature import peak_local_max
 from skimage.measure import label, regionprops
 from skimage.transform import resize
 from skimage.segmentation import random_walker, relabel_sequential
+from keras_retinanet.utils.compute_overlap import compute_overlap
 
 
 def noramlize(image):
@@ -179,6 +180,21 @@ def deepcell(prediction, threshold=.8):
     return labeled
 
 
+def compute_iou(boxes, mask_image):
+    overlaps = compute_overlap(boxes.astype('float64'), boxes.astype('float64'))
+    ind_x, ind_y = np.nonzero(overlaps)
+    ious = np.zeros(overlaps.shape)
+    for index in range(ind_x.shape[0]):
+        mask_a = mask_image[ind_x[index]]
+        mask_b = mask_image[ind_y[index]]
+        intersection = np.count_nonzero(np.logical_and(mask_a, mask_b))
+        union = np.count_nonzero(mask_a + mask_b)
+        if intersection > 0:
+            ious[ind_x[index], ind_y[index]] = intersection / union
+
+    return ious
+
+
 def retinanet_to_label_image(retinanet_outputs,
                              score_threshold=0.5,
                              multi_iou_threshold=0.25,
@@ -186,23 +202,6 @@ def retinanet_to_label_image(retinanet_outputs,
                              watershed_threshold=0.5,
                              perimeter_area_threshold=2,
                              small_objects_threshold=100):
-
-    def compute_iou(a, b):
-        """Computes the IoU overlap of boxes in a and b.
-        Args:
-            a: (N, H, W) ndarray of float
-            b: (K, H, W) ndarray of float
-        Returns
-            overlaps: (N, K) ndarray of overlap between boxes and query_boxes
-        """
-        intersection = np.zeros((a.shape[0], b.shape[0]))
-        union = np.zeros((a.shape[0], b.shape[0]))
-        for index, mask in enumerate(a):
-            intersection[index, :] = np.sum(np.count_nonzero(
-                np.logical_and(b, mask), axis=1), axis=1)
-            union[index, :] = np.sum(np.count_nonzero(b + mask, axis=1), axis=1)
-
-        return intersection / union
 
     boxes_batch = retinanet_outputs[-5]
     scores_batch = retinanet_outputs[-4]
@@ -216,6 +215,7 @@ def retinanet_to_label_image(retinanet_outputs,
 
     # Iterate over batches
     for i in range(boxes_batch.shape[0]):
+        print(i)
         boxes = boxes_batch[i]
         scores = scores_batch[i]
         labels = labels_batch[i]
@@ -240,7 +240,7 @@ def retinanet_to_label_image(retinanet_outputs,
             mask = (mask > binarize_threshold).astype('float32')
             mask_image[j, box[1]:box[3], box[0]:box[2]] = mask
 
-        ious = compute_iou(mask_image, mask_image)
+        ious = compute_iou(boxes, mask_image)
 
         # Identify all the masks with no overlaps and
         # add to the label matrix

--- a/redis_consumer/processing.py
+++ b/redis_consumer/processing.py
@@ -215,7 +215,6 @@ def retinanet_to_label_image(retinanet_outputs,
 
     # Iterate over batches
     for i in range(boxes_batch.shape[0]):
-        print(i)
         boxes = boxes_batch[i]
         scores = scores_batch[i]
         labels = labels_batch[i]

--- a/redis_consumer/processing.py
+++ b/redis_consumer/processing.py
@@ -305,7 +305,7 @@ def retinanet_to_label_image(retinanet_outputs,
             # Remove misshapen watershed cells
             props = regionprops(segments_semantic)
             for prop in props:
-                if prop.perimeter ** 2/prop.area > perimeter_area_threshold*4*np.pi:
+                if prop.perimeter ** 2 / prop.area > perimeter_area_threshold * 4 * np.pi:
                     segments_semantic[segments_semantic == prop.label] = 0
 
             masks_semantic = np.zeros((np.amax(segments_semantic).astype(int),

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -148,5 +148,14 @@ SCALE_DETECT_MODEL_VERSION = config("SCALE_DETECT_MODEL_VERSION", default=0)
 SCALE_DETECT_SAMPLE = config("SCALE_DETECT_SAMPLE", default=3)
 
 # Type detection settings
-TYPE_DETECT_MODEL_NAME = config("TYPE_DETECT_MODEL_NAME", default="LabelDetection")
-TYPE_DETECT_MODEL_VERSION = config("TYPE_DETECT_MODEL_VERSION", default=0)
+LABEL_DETECT_MODEL_NAME = config("LABEL_DETECT_MODEL_NAME", default="LabelDetection")
+LABEL_DETECT_MODEL_VERSION = config("LABEL_DETECT_MODEL_VERSION", default=0)
+LABEL_DETECT_SAMPLE = config("LABEL_DETECT_SAMPLE", default=3)
+
+# Set default models based on label type
+PHASE_MODEL_NAME = config("PHASE_MODEL_NAME", default='panoptic')
+PHASE_MODEL_VERSION = config("PHASE_MODEL_VERSION", default=1)
+CYTOPLASM_MODEL_NAME = config("CYTOPLASM_MODEL_NAME", default='panoptic')
+CYTOPLASM_MODEL_VERSION = config("CYTOPLASM_MODEL_VERSION", default=1)
+NUCLEAR_MODEL_NAME = config("NUCLEAR_MODEL_NAME", default='panoptic')
+NUCLEAR_MODEL_VERSION = config("NUCLEAR_MODEL_VERSION", default=1)

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -145,6 +145,7 @@ NEIGHBORHOOD_SCALE_SIZE = config('NEIGHBORHOOD_SCALE_SIZE', default=30)
 # Scale detection settings
 SCALE_DETECT_MODEL_NAME = config("SCALE_DETECT_MODEL_NAME", default="ScaleDetection")
 SCALE_DETECT_MODEL_VERSION = config("SCALE_DETECT_MODEL_VERSION", default=0)
+SCALE_DETECT_SAMPLE = config("SCALE_DETECT_SAMPLE", default=3)
 
 # Type detection settings
 TYPE_DETECT_MODEL_NAME = config("TYPE_DETECT_MODEL_NAME", default="LabelDetection")

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -118,13 +118,13 @@ EXPIRE_TIME = config('EXPIRE_TIME', default=3600, cast=int)
 # Pre- and Post-processing settings
 PROCESSING_FUNCTIONS = {
     'pre': {
-        'normalize': processing.noramlize,
+        'normalize': processing.noramlize
     },
     'post': {
         'deepcell': processing.deepcell,
         'mibi': processing.mibi,
         'watershed': processing.watershed,
-        'retinanet': processing.retinanet_to_label_image,
+        'retinanet': processing.retinanet_to_label_image
     },
 }
 
@@ -141,3 +141,7 @@ DIVISION = config('DIVISION', default=0.9)
 BIRTH = config('BIRTH', default=0.95)
 DEATH = config('DEATH', default=0.95)
 NEIGHBORHOOD_SCALE_SIZE = config('NEIGHBORHOOD_SCALE_SIZE', default=30)
+
+# Scale detection settings
+SCALE_DETECT_MODEL_NAME = config("SCALE_DETECT_MODEL_NAME", default="ScaleDetection")
+SCALE_DETECT_MODEL_VERSION = config("SCALE_DETECT_MODEL_VERSION", default=0)

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -143,7 +143,7 @@ DEATH = config('DEATH', default=0.95)
 NEIGHBORHOOD_SCALE_SIZE = config('NEIGHBORHOOD_SCALE_SIZE', default=30)
 
 # Scale detection settings
-SCALE_DETECT_MODEL = config("SCALE_DETECT_MODEL", default="ScaleDetection:0")
+SCALE_DETECT_MODEL = config("SCALE_DETECT_MODEL", default="ScaleDetection:2")
 SCALE_DETECT_SAMPLE = config("SCALE_DETECT_SAMPLE", default=3)
 SCALE_DETECT_ENABLED = config("SCALE_DETECT_ENABLED", default=True)
 
@@ -152,8 +152,8 @@ LABEL_DETECT_MODEL = config("LABEL_DETECT_MODEL", default="LabelDetection:0")
 LABEL_DETECT_SAMPLE = config("LABEL_DETECT_SAMPLE", default=3)
 
 # Set default models based on label type
-PHASE_MODEL = config("PHASE_MODEL", default='panoptic:3')
-CYTOPLASM_MODEL = config("CYTOPLASM_MODEL", default='panoptic:3')
+PHASE_MODEL = config("PHASE_MODEL", default='panoptic_phase:0')
+CYTOPLASM_MODEL = config("CYTOPLASM_MODEL", default='panoptic_cytoplasm:0')
 NUCLEAR_MODEL = config("NUCLEAR_MODEL", default='panoptic:3')
 
 MODEL_CHOICES = {

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -23,7 +23,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ============================================================================
-'''Settings file to hold environment variabls and constants'''
+"""Settings file to hold environment variabls and constants"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -145,3 +145,7 @@ NEIGHBORHOOD_SCALE_SIZE = config('NEIGHBORHOOD_SCALE_SIZE', default=30)
 # Scale detection settings
 SCALE_DETECT_MODEL_NAME = config("SCALE_DETECT_MODEL_NAME", default="ScaleDetection")
 SCALE_DETECT_MODEL_VERSION = config("SCALE_DETECT_MODEL_VERSION", default=0)
+
+# Type detection settings
+TYPE_DETECT_MODEL_NAME = config("TYPE_DETECT_MODEL_NAME", default="LabelDetection")
+TYPE_DETECT_MODEL_VERSION = config("TYPE_DETECT_MODEL_VERSION", default=0)

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -3,7 +3,7 @@
 # Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
 # All rights reserved.
 #
-# Licensed under a modified Apache License, Version 2.0 (the "License");
+# Licensed under a modified Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
@@ -18,12 +18,12 @@
 # prior written permission.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the License is distributed on an 'AS IS' BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ============================================================================
-"""Settings file to hold environment variabls and constants"""
+'''Settings file to hold environment variabls and constants'''
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -36,7 +36,7 @@ from decouple import config
 from redis_consumer import processing
 
 
-# remove leading/trailing "/"s from cloud bucket folder names
+# remove leading/trailing '/'s from cloud bucket folder names
 def _strip(x):
     return '/'.join(y for y in x.split('/') if y)
 
@@ -130,10 +130,12 @@ PROCESSING_FUNCTIONS = {
 }
 
 # Tracking settings
-MODEL_NAME = config('MODEL_NAME', default='HeLaS3watershed')
-MODEL_VERSION = config('MODEL_VERSION', default=2)
-POSTPROCESS_FUNCTION = config('POSTPROCESS_FUNCTION', default='watershed')
+TRACKING_SEGMENT_MODEL = config('TRACKING_SEGMENT_MODEL', default='panoptic:3')
+TRACKING_POSTPROCESS_FUNCTION = config('TRACKING_POSTPROCESS_FUNCTION', default='retinanet')
 CUTS = config('CUTS', default=0)
+
+TRACKING_MODEL = config(
+    'TRACKING_MODEL', default='tracking_model_benchmarking_757_step5_20epoch_80split_9tl:1')
 
 # tracking.cell_tracker settings
 MAX_DISTANCE = config('MAX_DISTANCE', default=50)
@@ -144,21 +146,35 @@ DEATH = config('DEATH', default=0.95)
 NEIGHBORHOOD_SCALE_SIZE = config('NEIGHBORHOOD_SCALE_SIZE', default=30)
 
 # Scale detection settings
-SCALE_DETECT_MODEL = config("SCALE_DETECT_MODEL", default="ScaleDetection:2")
-SCALE_DETECT_SAMPLE = config("SCALE_DETECT_SAMPLE", default=3)
-SCALE_DETECT_ENABLED = config("SCALE_DETECT_ENABLED", default=True)
+SCALE_DETECT_MODEL = config('SCALE_DETECT_MODEL', default='ScaleDetection:2')
+SCALE_DETECT_SAMPLE = config('SCALE_DETECT_SAMPLE', default=3)
+# Not supported for tracking. Always detects scale
+SCALE_DETECT_ENABLED = config('SCALE_DETECT_ENABLED', default=False)
+SCALE_RESHAPE_SIZE = config('SCALE_RESHAPE_SIZE', default=216)
 
 # Type detection settings
-LABEL_DETECT_MODEL = config("LABEL_DETECT_MODEL", default="LabelDetection:0")
-LABEL_DETECT_SAMPLE = config("LABEL_DETECT_SAMPLE", default=3)
+LABEL_DETECT_MODEL = config('LABEL_DETECT_MODEL', default='LabelDetection:0')
+LABEL_DETECT_SAMPLE = config('LABEL_DETECT_SAMPLE', default=3)
+LABEL_DETECT_ENABLED = config('LABEL_DETECT_ENABLED', default=False)
+LABEL_RESHAPE_SIZE = config('LABEL_RESHAPE_SIZE', default=216)
 
 # Set default models based on label type
-PHASE_MODEL = config("PHASE_MODEL", default='panoptic_phase:0')
-CYTOPLASM_MODEL = config("CYTOPLASM_MODEL", default='panoptic_cytoplasm:0')
-NUCLEAR_MODEL = config("NUCLEAR_MODEL", default='panoptic:3')
+PHASE_MODEL = config('PHASE_MODEL', default='panoptic_phase:0')
+CYTOPLASM_MODEL = config('CYTOPLASM_MODEL', default='panoptic_cytoplasm:0')
+NUCLEAR_MODEL = config('NUCLEAR_MODEL', default='panoptic:3')
 
 MODEL_CHOICES = {
     0: NUCLEAR_MODEL,
     1: PHASE_MODEL,
     2: CYTOPLASM_MODEL
+}
+
+PHASE_POSTPROCESS = config('PHASE_POSTPROCESS', default='retinanet')
+CYTOPLASM_POSTPROCESS = config('CYTOPLASM_POSTPROCESS', default='retinanet')
+NUCLEAR_POSTPROCESS = config('NUCLEAR_POSTPROCESS', default='retinanet')
+
+POSTPROCESS_CHOICES = {
+    0: NUCLEAR_POSTPROCESS,
+    1: PHASE_POSTPROCESS,
+    2: CYTOPLASM_POSTPROCESS
 }

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -143,19 +143,21 @@ DEATH = config('DEATH', default=0.95)
 NEIGHBORHOOD_SCALE_SIZE = config('NEIGHBORHOOD_SCALE_SIZE', default=30)
 
 # Scale detection settings
-SCALE_DETECT_MODEL_NAME = config("SCALE_DETECT_MODEL_NAME", default="ScaleDetection")
-SCALE_DETECT_MODEL_VERSION = config("SCALE_DETECT_MODEL_VERSION", default=0)
+SCALE_DETECT_MODEL = config("SCALE_DETECT_MODEL", default="ScaleDetection:0")
 SCALE_DETECT_SAMPLE = config("SCALE_DETECT_SAMPLE", default=3)
+SCALE_DETECT_ENABLED = config("SCALE_DETECT_ENABLED", default=True)
 
 # Type detection settings
-LABEL_DETECT_MODEL_NAME = config("LABEL_DETECT_MODEL_NAME", default="LabelDetection")
-LABEL_DETECT_MODEL_VERSION = config("LABEL_DETECT_MODEL_VERSION", default=0)
+LABEL_DETECT_MODEL = config("LABEL_DETECT_MODEL", default="LabelDetection:0")
 LABEL_DETECT_SAMPLE = config("LABEL_DETECT_SAMPLE", default=3)
 
 # Set default models based on label type
-PHASE_MODEL_NAME = config("PHASE_MODEL_NAME", default='panoptic')
-PHASE_MODEL_VERSION = config("PHASE_MODEL_VERSION", default=1)
-CYTOPLASM_MODEL_NAME = config("CYTOPLASM_MODEL_NAME", default='panoptic')
-CYTOPLASM_MODEL_VERSION = config("CYTOPLASM_MODEL_VERSION", default=1)
-NUCLEAR_MODEL_NAME = config("NUCLEAR_MODEL_NAME", default='panoptic')
-NUCLEAR_MODEL_VERSION = config("NUCLEAR_MODEL_VERSION", default=1)
+PHASE_MODEL = config("PHASE_MODEL", default='panoptic:3')
+CYTOPLASM_MODEL = config("CYTOPLASM_MODEL", default='panoptic:3')
+NUCLEAR_MODEL = config("NUCLEAR_MODEL", default='panoptic:3')
+
+MODEL_CHOICES = {
+    0: NUCLEAR_MODEL,
+    1: PHASE_MODEL,
+    2: CYTOPLASM_MODEL
+}

--- a/redis_consumer/utils.py
+++ b/redis_consumer/utils.py
@@ -423,6 +423,8 @@ def reshape_matrix(X, y, reshape_size=256, is_channels_first=False):
 
 
 def rescale(image, scale):
+    if scale == 1:
+        return image
     return skimage.transform.rescale(
         image, scale,
         mode='edge',
@@ -440,3 +442,12 @@ def _pick_model(label):
         raise ValueError('Label type {} is not supported'.format(label))
 
     return model.split(':')
+
+
+def _pick_postprocess(label):
+    func = settings.POSTPROCESS_CHOICES.get(label)
+    if func is None:
+        logger.error('Label type %s is not supported', label)
+        raise ValueError('Label type {} is not supported'.format(label))
+
+    return func

--- a/redis_consumer/utils.py
+++ b/redis_consumer/utils.py
@@ -353,7 +353,7 @@ def zip_files(files, dest=None, prefix=None):
     return filepath
 
 
-def reshape_matrix(X, y, reshape_size=256):
+def reshape_matrix(X, y, reshape_size=256, is_channels_first=False):
     """
     Reshape matrix of dimension 4 to have x and y of size reshape_size.
     Adds overlapping slices to batches.
@@ -363,11 +363,11 @@ def reshape_matrix(X, y, reshape_size=256):
         X: raw 4D image tensor
         y: label mask of 4D image data
         reshape_size: size of the square output tensor
+        is_channels_first: default False for channel dimension last
 
     Returns:
         reshaped `X` and `y` tensors in shape (`reshape_size`, `reshape_size`)
     """
-    is_channels_first = False  # K.image_data_format() == 'channels_first'
     if X.ndim != 4:
         raise ValueError('reshape_matrix expects X dim to be 4, got', X.ndim)
     elif y.ndim != 4:

--- a/redis_consumer/utils.py
+++ b/redis_consumer/utils.py
@@ -424,3 +424,12 @@ def rescale(image, scale):
         preserve_range=True,
         order=0
     )
+
+
+def _pick_model(label):
+
+    model = settings.MODEL_CHOICES.get(label, None)
+    if model is None:
+        self.logger.error('Label type %s is not supported', label)
+
+    return model.split(':')

--- a/redis_consumer/utils.py
+++ b/redis_consumer/utils.py
@@ -51,6 +51,7 @@ import PIL
 from redis_consumer.pbs.types_pb2 import DESCRIPTOR
 from redis_consumer.pbs.tensor_pb2 import TensorProto
 from redis_consumer.pbs.tensor_shape_pb2 import TensorShapeProto
+from redis_consumer import settings
 
 
 logger = logging.getLogger('redis_consumer.utils')
@@ -427,9 +428,9 @@ def rescale(image, scale):
 
 
 def _pick_model(label):
-
-    model = settings.MODEL_CHOICES.get(label, None)
+    model = settings.MODEL_CHOICES.get(label)
     if model is None:
-        self.logger.error('Label type %s is not supported', label)
+        logger.error('Label type %s is not supported', label)
+        raise ValueError('Label type {} is not supported'.format(label))
 
     return model.split(':')

--- a/redis_consumer/utils.py
+++ b/redis_consumer/utils.py
@@ -87,8 +87,6 @@ def grpc_response_to_dict(grpc_response):
     for k in grpc_response.outputs:
         shape = [x.size for x in grpc_response.outputs[k].tensor_shape.dim]
 
-        logger.debug('Key: %s, shape: %s', k, shape)
-
         dtype_constant = grpc_response.outputs[k].dtype
 
         if dtype_constant not in number_to_dtype_value:

--- a/redis_consumer/utils.py
+++ b/redis_consumer/utils.py
@@ -413,3 +413,14 @@ def reshape_matrix(X, y, reshape_size=256):
     print('Reshaped feature data from {} to {}'.format(y.shape, new_y.shape))
     print('Reshaped training data from {} to {}'.format(X.shape, new_X.shape))
     return new_X, new_y
+
+
+def rescale(image, scale):
+    return skimage.transform.rescale(
+        image, scale,
+        mode='edge',
+        anti_aliasing=False,
+        anti_aliasing_sigma=None,
+        preserve_range=True,
+        order=0
+    )

--- a/redis_consumer/utils_test.py
+++ b/redis_consumer/utils_test.py
@@ -35,6 +35,7 @@ import pytest
 import tarfile
 import tempfile
 import zipfile
+from tensorflow.python.platform import test
 
 from keras_preprocessing.image import array_to_img
 from skimage.external import tifffile as tiff
@@ -273,56 +274,58 @@ def test_zip_files():
             zip_path = utils.zip_files(paths, bad_dest, prefix)
 
 
-def test_reshape_matrix(self):
-    # K.set_image_data_format('channels_last')
-    X = np.zeros((1, 16, 16, 3))
-    y = np.zeros((1, 16, 16, 1))
-    new_size = 4
+class TestDataUtils(test.TestCase):
 
-    # test resize to smaller image, divisible
-    new_X, new_y = data_utils.reshape_matrix(X, y, new_size)
-    new_batch = np.ceil(16 / new_size) ** 2
-    self.assertEqual(new_X.shape, (new_batch, new_size, new_size, 3))
-    self.assertEqual(new_y.shape, (new_batch, new_size, new_size, 1))
+    def test_reshape_matrix(self):
+        # K.set_image_data_format('channels_last')
+        X = np.zeros((1, 16, 16, 3))
+        y = np.zeros((1, 16, 16, 1))
+        new_size = 4
 
-    # test reshape with non-divisible values.
-    new_size = 5
-    new_batch = np.ceil(16 / new_size) ** 2
-    new_X, new_y = data_utils.reshape_matrix(X, y, new_size)
-    self.assertEqual(new_X.shape, (new_batch, new_size, new_size, 3))
-    self.assertEqual(new_y.shape, (new_batch, new_size, new_size, 1))
+        # test resize to smaller image, divisible
+        new_X, new_y = utils.reshape_matrix(X, y, new_size)
+        new_batch = np.ceil(16 / new_size) ** 2
+        self.assertEqual(new_X.shape, (new_batch, new_size, new_size, 3))
+        self.assertEqual(new_y.shape, (new_batch, new_size, new_size, 1))
 
-    # test reshape to bigger size
-    with self.assertRaises(ValueError):
-        new_X, new_y = data_utils.reshape_matrix(X, y, 32)
+        # test reshape with non-divisible values.
+        new_size = 5
+        new_batch = np.ceil(16 / new_size) ** 2
+        new_X, new_y = utils.reshape_matrix(X, y, new_size)
+        self.assertEqual(new_X.shape, (new_batch, new_size, new_size, 3))
+        self.assertEqual(new_y.shape, (new_batch, new_size, new_size, 1))
 
-    # test wrong dimensions
-    bigger = np.zeros((1, 16, 16, 3, 1))
-    smaller = np.zeros((1, 16, 16))
-    with self.assertRaises(ValueError):
-        new_X, new_y = data_utils.reshape_matrix(smaller, y, new_size)
-    with self.assertRaises(ValueError):
-        new_X, new_y = data_utils.reshape_matrix(bigger, y, new_size)
-    with self.assertRaises(ValueError):
-        new_X, new_y = data_utils.reshape_matrix(X, smaller, new_size)
-    with self.assertRaises(ValueError):
-        new_X, new_y = data_utils.reshape_matrix(X, bigger, new_size)
+        # test reshape to bigger size
+        with self.assertRaises(ValueError):
+            new_X, new_y = utils.reshape_matrix(X, y, 32)
 
-    # channels_first
-    # K.set_image_data_format('channels_first')
-    X = np.zeros((1, 3, 16, 16))
-    y = np.zeros((1, 1, 16, 16))
-    new_size = 4
+        # test wrong dimensions
+        bigger = np.zeros((1, 16, 16, 3, 1))
+        smaller = np.zeros((1, 16, 16))
+        with self.assertRaises(ValueError):
+            new_X, new_y = utils.reshape_matrix(smaller, y, new_size)
+        with self.assertRaises(ValueError):
+            new_X, new_y = utils.reshape_matrix(bigger, y, new_size)
+        with self.assertRaises(ValueError):
+            new_X, new_y = utils.reshape_matrix(X, smaller, new_size)
+        with self.assertRaises(ValueError):
+            new_X, new_y = utils.reshape_matrix(X, bigger, new_size)
 
-    # test resize to smaller image, divisible
-    new_X, new_y = data_utils.reshape_matrix(X, y, new_size)
-    new_batch = np.ceil(16 / new_size) ** 2
-    self.assertEqual(new_X.shape, (new_batch, 3, new_size, new_size))
-    self.assertEqual(new_y.shape, (new_batch, 1, new_size, new_size))
+        # channels_first
+        # K.set_image_data_format('channels_first')
+        X = np.zeros((1, 3, 16, 16))
+        y = np.zeros((1, 1, 16, 16))
+        new_size = 4
 
-    # test reshape with non-divisible values.
-    new_size = 5
-    new_batch = np.ceil(16 / new_size) ** 2
-    new_X, new_y = data_utils.reshape_matrix(X, y, new_size)
-    self.assertEqual(new_X.shape, (new_batch, 3, new_size, new_size))
-    self.assertEqual(new_y.shape, (new_batch, 1, new_size, new_size))
+        # test resize to smaller image, divisible
+        new_X, new_y = utils.reshape_matrix(X, y, new_size)
+        new_batch = np.ceil(16 / new_size) ** 2
+        self.assertEqual(new_X.shape, (new_batch, 3, new_size, new_size))
+        self.assertEqual(new_y.shape, (new_batch, 1, new_size, new_size))
+
+        # test reshape with non-divisible values.
+        new_size = 5
+        new_batch = np.ceil(16 / new_size) ** 2
+        new_X, new_y = utils.reshape_matrix(X, y, new_size)
+        self.assertEqual(new_X.shape, (new_batch, 3, new_size, new_size))
+        self.assertEqual(new_y.shape, (new_batch, 1, new_size, new_size))

--- a/redis_consumer/utils_test.py
+++ b/redis_consumer/utils_test.py
@@ -271,3 +271,58 @@ def test_zip_files():
         with pytest.raises(Exception):
             bad_dest = os.path.join(temp_dir, 'does', 'not', 'exist')
             zip_path = utils.zip_files(paths, bad_dest, prefix)
+
+
+def test_reshape_matrix(self):
+    # K.set_image_data_format('channels_last')
+    X = np.zeros((1, 16, 16, 3))
+    y = np.zeros((1, 16, 16, 1))
+    new_size = 4
+
+    # test resize to smaller image, divisible
+    new_X, new_y = data_utils.reshape_matrix(X, y, new_size)
+    new_batch = np.ceil(16 / new_size) ** 2
+    self.assertEqual(new_X.shape, (new_batch, new_size, new_size, 3))
+    self.assertEqual(new_y.shape, (new_batch, new_size, new_size, 1))
+
+    # test reshape with non-divisible values.
+    new_size = 5
+    new_batch = np.ceil(16 / new_size) ** 2
+    new_X, new_y = data_utils.reshape_matrix(X, y, new_size)
+    self.assertEqual(new_X.shape, (new_batch, new_size, new_size, 3))
+    self.assertEqual(new_y.shape, (new_batch, new_size, new_size, 1))
+
+    # test reshape to bigger size
+    with self.assertRaises(ValueError):
+        new_X, new_y = data_utils.reshape_matrix(X, y, 32)
+
+    # test wrong dimensions
+    bigger = np.zeros((1, 16, 16, 3, 1))
+    smaller = np.zeros((1, 16, 16))
+    with self.assertRaises(ValueError):
+        new_X, new_y = data_utils.reshape_matrix(smaller, y, new_size)
+    with self.assertRaises(ValueError):
+        new_X, new_y = data_utils.reshape_matrix(bigger, y, new_size)
+    with self.assertRaises(ValueError):
+        new_X, new_y = data_utils.reshape_matrix(X, smaller, new_size)
+    with self.assertRaises(ValueError):
+        new_X, new_y = data_utils.reshape_matrix(X, bigger, new_size)
+
+    # channels_first
+    # K.set_image_data_format('channels_first')
+    X = np.zeros((1, 3, 16, 16))
+    y = np.zeros((1, 1, 16, 16))
+    new_size = 4
+
+    # test resize to smaller image, divisible
+    new_X, new_y = data_utils.reshape_matrix(X, y, new_size)
+    new_batch = np.ceil(16 / new_size) ** 2
+    self.assertEqual(new_X.shape, (new_batch, 3, new_size, new_size))
+    self.assertEqual(new_y.shape, (new_batch, 1, new_size, new_size))
+
+    # test reshape with non-divisible values.
+    new_size = 5
+    new_batch = np.ceil(16 / new_size) ** 2
+    new_X, new_y = data_utils.reshape_matrix(X, y, new_size)
+    self.assertEqual(new_X.shape, (new_batch, 3, new_size, new_size))
+    self.assertEqual(new_y.shape, (new_batch, 1, new_size, new_size))

--- a/redis_consumer/utils_test.py
+++ b/redis_consumer/utils_test.py
@@ -35,7 +35,6 @@ import pytest
 import tarfile
 import tempfile
 import zipfile
-from unittest import TestCase
 
 from keras_preprocessing.image import array_to_img
 from skimage.external import tifffile as tiff
@@ -274,58 +273,56 @@ def test_zip_files():
             zip_path = utils.zip_files(paths, bad_dest, prefix)
 
 
-class TestDataUtils(TestCase):
+def test_reshape_matrix(self):
+    # K.set_image_data_format('channels_last')
+    X = np.zeros((1, 16, 16, 3))
+    y = np.zeros((1, 16, 16, 1))
+    new_size = 4
 
-    def test_reshape_matrix(self):
-        # K.set_image_data_format('channels_last')
-        X = np.zeros((1, 16, 16, 3))
-        y = np.zeros((1, 16, 16, 1))
-        new_size = 4
+    # test resize to smaller image, divisible
+    new_X, new_y = data_utils.reshape_matrix(X, y, new_size)
+    new_batch = np.ceil(16 / new_size) ** 2
+    assert new_X.shape == (new_batch, new_size, new_size, 3)
+    assert new_y.shape == (new_batch, new_size, new_size, 1)
 
-        # test resize to smaller image, divisible
-        new_X, new_y = utils.reshape_matrix(X, y, new_size)
-        new_batch = np.ceil(16 / new_size) ** 2
-        self.assertEqual(new_X.shape, (new_batch, new_size, new_size, 3))
-        self.assertEqual(new_y.shape, (new_batch, new_size, new_size, 1))
+    # test reshape with non-divisible values.
+    new_size = 5
+    new_batch = np.ceil(16 / new_size) ** 2
+    new_X, new_y = data_utils.reshape_matrix(X, y, new_size)
+    assert new_X.shape == (new_batch, new_size, new_size, 3)
+    assert new_y.shape == (new_batch, new_size, new_size, 1)
 
-        # test reshape with non-divisible values.
-        new_size = 5
-        new_batch = np.ceil(16 / new_size) ** 2
-        new_X, new_y = utils.reshape_matrix(X, y, new_size)
-        self.assertEqual(new_X.shape, (new_batch, new_size, new_size, 3))
-        self.assertEqual(new_y.shape, (new_batch, new_size, new_size, 1))
+    # test reshape to bigger size
+    with pytest.raises(ValueError):
+        new_X, new_y = data_utils.reshape_matrix(X, y, 32)
 
-        # test reshape to bigger size
-        with self.assertRaises(ValueError):
-            new_X, new_y = utils.reshape_matrix(X, y, 32)
+    # test wrong dimensions
+    bigger = np.zeros((1, 16, 16, 3, 1))
+    smaller = np.zeros((1, 16, 16))
+    with pytest.raises(ValueError):
+        new_X, new_y = data_utils.reshape_matrix(smaller, y, new_size)
+    with pytest.raises(ValueError):
+        new_X, new_y = data_utils.reshape_matrix(bigger, y, new_size)
+    with pytest.raises(ValueError):
+        new_X, new_y = data_utils.reshape_matrix(X, smaller, new_size)
+    with pytest.raises(ValueError):
+        new_X, new_y = data_utils.reshape_matrix(X, bigger, new_size)
 
-        # test wrong dimensions
-        bigger = np.zeros((1, 16, 16, 3, 1))
-        smaller = np.zeros((1, 16, 16))
-        with self.assertRaises(ValueError):
-            new_X, new_y = utils.reshape_matrix(smaller, y, new_size)
-        with self.assertRaises(ValueError):
-            new_X, new_y = utils.reshape_matrix(bigger, y, new_size)
-        with self.assertRaises(ValueError):
-            new_X, new_y = utils.reshape_matrix(X, smaller, new_size)
-        with self.assertRaises(ValueError):
-            new_X, new_y = utils.reshape_matrix(X, bigger, new_size)
+    # channels_first
+    # K.set_image_data_format('channels_first')
+    X = np.zeros((1, 3, 16, 16))
+    y = np.zeros((1, 1, 16, 16))
+    new_size = 4
 
-        # channels_first
-        # K.set_image_data_format('channels_first')
-        X = np.zeros((1, 3, 16, 16))
-        y = np.zeros((1, 1, 16, 16))
-        new_size = 4
+    # test resize to smaller image, divisible
+    new_X, new_y = data_utils.reshape_matrix(X, y, new_size)
+    new_batch = np.ceil(16 / new_size) ** 2
+    assert new_X.shape == (new_batch, 3, new_size, new_size)
+    assert new_y.shape == (new_batch, 1, new_size, new_size)
 
-        # test resize to smaller image, divisible
-        new_X, new_y = utils.reshape_matrix(X, y, new_size, is_channels_first=True)
-        new_batch = np.ceil(16 / new_size) ** 2
-        self.assertEqual(new_X.shape, (new_batch, 3, new_size, new_size))
-        self.assertEqual(new_y.shape, (new_batch, 1, new_size, new_size))
-
-        # test reshape with non-divisible values.
-        new_size = 5
-        new_batch = np.ceil(16 / new_size) ** 2
-        new_X, new_y = utils.reshape_matrix(X, y, new_size, is_channels_first=True)
-        self.assertEqual(new_X.shape, (new_batch, 3, new_size, new_size))
-        self.assertEqual(new_y.shape, (new_batch, 1, new_size, new_size))
+    # test reshape with non-divisible values.
+    new_size = 5
+    new_batch = np.ceil(16 / new_size) ** 2
+    new_X, new_y = data_utils.reshape_matrix(X, y, new_size)
+    assert new_X.shape == (new_batch, 3, new_size, new_size)
+    assert new_y.shape == (new_batch, 1, new_size, new_size)

--- a/redis_consumer/utils_test.py
+++ b/redis_consumer/utils_test.py
@@ -273,14 +273,14 @@ def test_zip_files():
             zip_path = utils.zip_files(paths, bad_dest, prefix)
 
 
-def test_reshape_matrix(self):
+def test_reshape_matrix():
     # K.set_image_data_format('channels_last')
     X = np.zeros((1, 16, 16, 3))
     y = np.zeros((1, 16, 16, 1))
     new_size = 4
 
     # test resize to smaller image, divisible
-    new_X, new_y = data_utils.reshape_matrix(X, y, new_size)
+    new_X, new_y = utils.reshape_matrix(X, y, new_size)
     new_batch = np.ceil(16 / new_size) ** 2
     assert new_X.shape == (new_batch, new_size, new_size, 3)
     assert new_y.shape == (new_batch, new_size, new_size, 1)
@@ -288,25 +288,25 @@ def test_reshape_matrix(self):
     # test reshape with non-divisible values.
     new_size = 5
     new_batch = np.ceil(16 / new_size) ** 2
-    new_X, new_y = data_utils.reshape_matrix(X, y, new_size)
+    new_X, new_y = utils.reshape_matrix(X, y, new_size)
     assert new_X.shape == (new_batch, new_size, new_size, 3)
     assert new_y.shape == (new_batch, new_size, new_size, 1)
 
     # test reshape to bigger size
     with pytest.raises(ValueError):
-        new_X, new_y = data_utils.reshape_matrix(X, y, 32)
+        new_X, new_y = utils.reshape_matrix(X, y, 32)
 
     # test wrong dimensions
     bigger = np.zeros((1, 16, 16, 3, 1))
     smaller = np.zeros((1, 16, 16))
     with pytest.raises(ValueError):
-        new_X, new_y = data_utils.reshape_matrix(smaller, y, new_size)
+        new_X, new_y = utils.reshape_matrix(smaller, y, new_size)
     with pytest.raises(ValueError):
-        new_X, new_y = data_utils.reshape_matrix(bigger, y, new_size)
+        new_X, new_y = utils.reshape_matrix(bigger, y, new_size)
     with pytest.raises(ValueError):
-        new_X, new_y = data_utils.reshape_matrix(X, smaller, new_size)
+        new_X, new_y = utils.reshape_matrix(X, smaller, new_size)
     with pytest.raises(ValueError):
-        new_X, new_y = data_utils.reshape_matrix(X, bigger, new_size)
+        new_X, new_y = utils.reshape_matrix(X, bigger, new_size)
 
     # channels_first
     # K.set_image_data_format('channels_first')
@@ -315,7 +315,7 @@ def test_reshape_matrix(self):
     new_size = 4
 
     # test resize to smaller image, divisible
-    new_X, new_y = data_utils.reshape_matrix(X, y, new_size)
+    new_X, new_y = utils.reshape_matrix(X, y, new_size, True)
     new_batch = np.ceil(16 / new_size) ** 2
     assert new_X.shape == (new_batch, 3, new_size, new_size)
     assert new_y.shape == (new_batch, 1, new_size, new_size)
@@ -323,6 +323,6 @@ def test_reshape_matrix(self):
     # test reshape with non-divisible values.
     new_size = 5
     new_batch = np.ceil(16 / new_size) ** 2
-    new_X, new_y = data_utils.reshape_matrix(X, y, new_size)
+    new_X, new_y = utils.reshape_matrix(X, y, new_size, True)
     assert new_X.shape == (new_batch, 3, new_size, new_size)
     assert new_y.shape == (new_batch, 1, new_size, new_size)

--- a/redis_consumer/utils_test.py
+++ b/redis_consumer/utils_test.py
@@ -35,7 +35,7 @@ import pytest
 import tarfile
 import tempfile
 import zipfile
-from tensorflow.python.platform import test
+from unittest import TestCase
 
 from keras_preprocessing.image import array_to_img
 from skimage.external import tifffile as tiff
@@ -274,7 +274,7 @@ def test_zip_files():
             zip_path = utils.zip_files(paths, bad_dest, prefix)
 
 
-class TestDataUtils(test.TestCase):
+class TestDataUtils(TestCase):
 
     def test_reshape_matrix(self):
         # K.set_image_data_format('channels_last')
@@ -318,7 +318,7 @@ class TestDataUtils(test.TestCase):
         new_size = 4
 
         # test resize to smaller image, divisible
-        new_X, new_y = utils.reshape_matrix(X, y, new_size)
+        new_X, new_y = utils.reshape_matrix(X, y, new_size, is_channels_first=True)
         new_batch = np.ceil(16 / new_size) ** 2
         self.assertEqual(new_X.shape, (new_batch, 3, new_size, new_size))
         self.assertEqual(new_y.shape, (new_batch, 1, new_size, new_size))
@@ -326,6 +326,6 @@ class TestDataUtils(test.TestCase):
         # test reshape with non-divisible values.
         new_size = 5
         new_batch = np.ceil(16 / new_size) ** 2
-        new_X, new_y = utils.reshape_matrix(X, y, new_size)
+        new_X, new_y = utils.reshape_matrix(X, y, new_size, is_channels_first=True)
         self.assertEqual(new_X.shape, (new_batch, 3, new_size, new_size))
         self.assertEqual(new_y.shape, (new_batch, 1, new_size, new_size))

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ grpcio==1.22.0
 dict-to-protobuf==0.0.3.9
 pandas>=0.24.2
 pytz==2019.1
-git+git://github.com/fizyr/keras-retinanet.git
+keras_retinanet==0.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ grpcio==1.22.0
 dict-to-protobuf==0.0.3.9
 pandas>=0.24.2
 pytz==2019.1
+git+git://github.com/fizyr/keras-retinanet.git


### PR DESCRIPTION
- Create new tensorflow serving consumer class to manage functions associated with predict calls
- Modify ImageConsumer and TrackingConsumer to inherit from TensorFlowServingConsumer
- New images go through scale detection and rescaling before segmentation. Scale is restored before returning image to user
- Label detection model classifies each image as nuclear, brightfield or fluorescent cytoplasm
- Settings.py contains additional parameters including which model to use in each label case
- Scale and label predictions are generated on a subsampling of input data
- Tracking predicts scale and label on the whole stack and then passes those values to the ImageConsumer