### PR TITLE
Consumer._consume() returns the current status of the job.

### DIFF
--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -114,9 +114,11 @@ class Consumer(object):
             if self.is_valid_hash(redis_hash):
                 return redis_hash
 
-            # this invalid hash should not be processed by this consumer.
-            # remove it from processing, and push it back to the work queue.
-            self._put_back_hash(redis_hash)
+            # hash is invalid. it should not be in this queue.
+            self.logger.warning('Found invalid hash in %s: `%s` with '
+                                'hvals: %s', self.queue, redis_hash,
+                                self.redis.hgetall(redis_hash))
+            self.redis.lrem(self.processing_queue, 1, redis_hash)
 
     def _handle_error(self, err, redis_hash):
         """Update redis with failure information, and log errors.

--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -921,7 +921,7 @@ class ZipFileConsumer(Consumer):
             })
             return next_status
 
-        elif status == 'waiting':
+        if status == 'waiting':
             # this key was previously processed by a ZipConsumer
             # check to see which child keys have already been processed
             children = set(hvals.get('children', '').split(key_separator))
@@ -951,7 +951,9 @@ class ZipFileConsumer(Consumer):
             if not remaining_children:
                 self._cleanup(redis_hash, children, done, failed)
                 return self.final_status
+
             return status
+
         self.logger.error('Found strange status for key `%s`: %s.',
                           redis_hash, status)
         return status

--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -188,6 +188,7 @@ class Consumer(object):
             except Exception as err:  # pylint: disable=broad-except
                 # log the error and update redis with details
                 self._handle_error(err, redis_hash)
+                status = self.failed_status
 
             if status == self.final_status:
                 required_fields = [

--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -844,6 +844,7 @@ class ZipFileConsumer(Consumer):
 
         summaries = dict()
         for d in done:
+            # TODO: stale data may still be Null, causing missing results.
             results = self.redis.hmget(d, *summary_fields)
             for field, result in zip(summary_fields, results):
                 try:

--- a/redis_consumer/consumers_test.py
+++ b/redis_consumer/consumers_test.py
@@ -188,17 +188,16 @@ class TestConsumer(object):
         rhash = consumer.get_redis_hash()
         assert rhash is None
 
-        # test some valid/invalid items
-        items = ['item%s' % x for x in range(1, 4)]
+        # test that invalid items are not processed and are removed.
+        items = ['item%s:file.tif:new' % x for x in range(1, 4)]
         redis_client = DummyRedis(items, prefix=queue_name)
 
         consumer = consumers.Consumer(redis_client, None, queue_name)
-        consumer.is_valid_hash = lambda x: x == 'item1'
-        print(redis_client.work_queue)
+        consumer.is_valid_hash = lambda x: x.startswith('item1')
 
         rhash = consumer.get_redis_hash()
         assert rhash == items[0]
-        assert redis_client.work_queue == items[1:]
+        assert redis_client.work_queue == []
         assert redis_client.processing_queue == items[0:1]
 
     def test_purge_processing_queue(self):


### PR DESCRIPTION
After `_consume` is called, the consumer decides what to do with the key based on its status, which it fetches from Redis after the job is finished. During high volume runs, Redis may return slightly stale data.  This causes keys that are `done` getting put back into the work queue, causing them to be re-processed.

To resolve this, `_consume` returns the most recent status and the consumer uses this resulting status to decide what to do with the key.  This reduces the number of Redis calls and ensures we are not using stale data when moving the keys around.

* Updated `cleanup` to set the final status and log

* `_consume` returns the status most recently set status which `consume` then uses to determine whether to put the key back for future work or remove it.

* Added `consumer.failed_status` which defaults to `"failed"` instead of hard-coding it, and added `consumer.finished_statuses` for easier completion lookups.

* `get_redis_hash` removes hashes if they are invalid.

* if `_consume` is called on a completed key, it immediately returns the key's status.
