### PR TITLE
Update deepcell-tracking to 0.2.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ pytz==2019.1
 keras_retinanet==0.5.1
 opencv-python==4.1.0.25
 networkx>=2.1
-deepcell-tracking==0.2.3
+deepcell-tracking==0.2.4


### PR DESCRIPTION
Pin `deepcell-tracking` to the new release, 0.2.4.