### PR TITLE
Add SEGMENTATION_QUEUE env var for tracking-consumer

### DIFF
--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -730,7 +730,7 @@ class ZipFileConsumer(Consumer):
                 os.remove(imfile)  # remove the file to save some memory
 
                 new_hash = '{prefix}:{file}:{hash}'.format(
-                    prefix=settings.HASH_PREFIX,
+                    prefix=self.child_queue,
                     file=clean_imfile,
                     hash=uuid.uuid4().hex)
 

--- a/redis_consumer/consumers.py
+++ b/redis_consumer/consumers.py
@@ -1160,13 +1160,13 @@ class TrackingConsumer(TensorFlowServingConsumer):
 
                 # make a hash for this frame
                 segment_hash = '{prefix}:{file}:{hash}'.format(
-                    prefix='predict',
+                    prefix=settings.SEGMENTATION_QUEUE,
                     file=segment_fname,
                     hash=uuid.uuid4().hex)
 
                 # push the hash to redis and the predict queue
                 self.redis.hmset(segment_hash, frame_hvalues)
-                self.redis.lpush('predict', segment_hash)
+                self.redis.lpush(settings.SEGMENTATION_QUEUE, segment_hash)
                 self.logger.debug('Added new hash for segmentation `%s`: %s',
                                   segment_hash, json.dumps(frame_hvalues,
                                                            indent=4))

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -109,8 +109,8 @@ GCLOUD_STORAGE_BUCKET = config('GKE_BUCKET', default='default-bucket')
 HOSTNAME = config('HOSTNAME', default='host-unkonwn')
 
 # Redis queue
-QUEUE = config('QUEUE', default='segmentation')
-SEGMENTATION_QUEUE = config('SEGMENTATION_QUEUE', default='segmentation')
+QUEUE = config('QUEUE', default='predict')
+SEGMENTATION_QUEUE = config('SEGMENTATION_QUEUE', default='predict')
 
 # Configure expiration time for child keys
 EXPIRE_TIME = config('EXPIRE_TIME', default=3600, cast=int)

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -109,7 +109,8 @@ GCLOUD_STORAGE_BUCKET = config('GKE_BUCKET', default='default-bucket')
 HOSTNAME = config('HOSTNAME', default='host-unkonwn')
 
 # Redis queue
-QUEUE = config('QUEUE', default='predict')
+QUEUE = config('QUEUE', default='segmentation')
+SEGMENTATION_QUEUE = config('SEGMENTATION_QUEUE', default='segmentation')
 
 # Configure expiration time for child keys
 EXPIRE_TIME = config('EXPIRE_TIME', default=3600, cast=int)

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -49,9 +49,6 @@ INTERVAL = config('INTERVAL', default=10, cast=int)
 CONSUMER_TYPE = config('CONSUMER_TYPE', default='image')
 MAX_RETRY = config('MAX_RETRY', default=5, cast=int)
 
-# Hash Prefix - filter out prediction jobs
-HASH_PREFIX = _strip(config('HASH_PREFIX', cast=str, default='predict'))
-
 # Redis client connection
 REDIS_HOST = config('REDIS_HOST', default='redis-master')
 REDIS_PORT = config('REDIS_PORT', default=6379, cast=int)


### PR DESCRIPTION
The tracking-consumer currently pushes all segmentation work into the hard-coded `"predict"` queue.  This has been changed to use an environment variable, `SEGMENTATION_QUEUE`.  This allows a customized segmentation pipeline based on environment variables.