### PR TITLE
Update for python 2 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,11 @@ cache: pip
 install:
   - pip install -r requirements.txt
   - pip install pytest pytest-cov==2.5.1 pytest-pep8 coveralls
-  # - pip install -r docs/rtd-requirements.txt
+  - pip install -r docs/rtd-requirements.txt
 
 script:
   - PYTHONPATH=$PWD:$PYTHONPATH pytest --cov=redis_consumer --pep8
-  # - PYTHONPATH=$PWD:$PYTHONPATH sphinx-build -nT -b dummy ./docs/source build/html
+  - PYTHONPATH=$PWD:$PYTHONPATH sphinx-build -nT -b dummy ./docs/source build/html
 
 jobs:
   include:

--- a/docs/rtd-requirements.txt
+++ b/docs/rtd-requirements.txt
@@ -1,6 +1,6 @@
 m2r
 mock==3.0.5
-Sphinx==2.3.1
+Sphinx>=1.8.5
 
 boto3==1.9.195
 google-cloud-storage>=1.16.1

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,12 @@
 import os
 import sys
 from datetime import datetime
-import urllib.request
+
+try:
+    from urllib.request import urlretrieve
+except ImportError:
+    from urllib import urlretrieve
+
 sys.path.insert(0, os.path.abspath('../..'))
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__))))
 
@@ -218,7 +223,7 @@ intersphinx_cache_limit = 0
 # -- Custom Document processing ----------------------------------------------
 
 # Download gensidebar
-urllib.request.urlretrieve(
+urlretrieve(
     'https://raw.githubusercontent.com/vanvalenlab/kiosk/{}/docs/source/gensidebar.py'.format(
         rtd_version),
     'gensidebar.py'


### PR DESCRIPTION
* Update `docs/conf.py` to be general to python 2 and 3.
* Update `Sphinx` to `>=1.8.5` to allow python 2 to install it.

Is 2.3.1 a required version for a particular reason? If so, this may not work.