### PR TITLE
Always assign model_version in the PredictClient.

### DIFF
--- a/redis_consumer/grpc_clients.py
+++ b/redis_consumer/grpc_clients.py
@@ -172,9 +172,7 @@ class PredictClient(GrpcClient):
 
         # pylint: disable=E1101
         request.model_spec.name = self.model_name
-
-        if self.model_version > 0:
-            request.model_spec.version.value = self.model_version
+        request.model_spec.version.value = self.model_version
 
         t = timeit.default_timer()
         for d in request_data:
@@ -200,8 +198,7 @@ class PredictClient(GrpcClient):
         request = GetModelMetadataRequest()
         request.metadata_field.append('signature_def')
         request.model_spec.name = self.model_name
-        if self.model_version > 0:
-            request.model_spec.version.value = self.model_version
+        request.model_spec.version.value = self.model_version
 
         response = self._retry_grpc(request, request_timeout)
 


### PR DESCRIPTION
Removes an `if model_version > 0` conditional statement during PredictClient request construction. if `model_version <= 0` the version is not assigned to the request, and tf-serving will use the default value of the latest version available. This may cause data to be sent to the incorrect model.