### PR TITLE
Replace TF_TENSOR_NAME with ModelMetadata response.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ The consumer is configured using environment variables. Please find a table of a
 | `METADATA_EXPIRE_TIME` | Expire cached model metadata after this many seconds. | `30` |
 | `TF_HOST` | The IP address or hostname of TensorFlow Serving. | `"tf-serving"` |
 | `TF_PORT` | The port used to connect to TensorFlow Serving. | `8500` |
-| `TF_TENSOR_NAME` | Name of input tensor for the exported model. | `"image"` |
 | `GRPC_TIMEOUT` | Timeout for gRPC API requests, in seconds. | `30` |
 | `GRPC_BACKOFF` | Time to wait before retrying a gRPC API request. | `3` |
 | `MAX_RETRY` | Maximum number of retries for a failed TensorFlow Serving request. | `5` |

--- a/redis_consumer/consumers/base_consumer.py
+++ b/redis_consumer/consumers/base_consumer.py
@@ -361,8 +361,8 @@ class TensorFlowServingConsumer(Consumer):
                            model_name,
                            model_version,
                            model_shape,
-                           model_dtype='DT_FLOAT',
                            model_input_name='image',
+                           model_dtype='DT_FLOAT',
                            untile=True,
                            stride_ratio=0.75):
         """Use tile_image to tile image for the model and untile the results.

--- a/redis_consumer/consumers/base_consumer.py
+++ b/redis_consumer/consumers/base_consumer.py
@@ -326,8 +326,9 @@ class TensorFlowServingConsumer(Consumer):
             inputs = inputs['serving_default']['inputs']
 
             if len(inputs) > 1:
-                self.logger.error('Model has %s inputs defined but was only '
-                                  'passed a single input.')
+                raise ValueError('Models with more than 1 required input are '
+                                 'not yet supported. Got the following named '
+                                 'inputs: {}'.format(list(inputs)))
 
             # TODO: handle multiple inputs in a general way.
             input_name = list(inputs.keys())[0]

--- a/redis_consumer/consumers/base_consumer_test.py
+++ b/redis_consumer/consumers/base_consumer_test.py
@@ -358,9 +358,16 @@ class TestTensorFlowServingConsumer(object):
         consumer._get_predict_client = _get_predict_client
 
         img = np.zeros((1, 32, 32, 3))
-        out = consumer.grpc_image(img, 'model', 1, model_shape, 'DT_HALF')
+        out = consumer.grpc_image(img, 'model', 1, model_shape, 'i', 'DT_HALF')
 
         assert img.shape == out.shape
+        assert img.sum() == out.sum()
+
+        img = np.zeros((32, 32, 3))
+        consumer._redis_hash = None
+        out = consumer.grpc_image(img, 'model', 1, model_shape, 'i', 'DT_HALF')
+
+        assert (1,) + img.shape == out.shape
         assert img.sum() == out.sum()
 
     def test_get_model_metadata(self):

--- a/redis_consumer/consumers/base_consumer_test.py
+++ b/redis_consumer/consumers/base_consumer_test.py
@@ -494,6 +494,7 @@ class TestTensorFlowServingConsumer(object):
                     x = np.random.random(image_shape)
                     consumer.grpc_image = grpc_func
                     consumer.get_model_metadata = lambda x, y: {
+                        'in_tensor_name': 'image',
                         'in_tensor_dtype': 'DT_HALF',
                         'in_tensor_shape': ','.join(str(s) for s in model_shape),
                     }

--- a/redis_consumer/consumers/base_consumer_test.py
+++ b/redis_consumer/consumers/base_consumer_test.py
@@ -364,7 +364,7 @@ class TestTensorFlowServingConsumer(object):
         assert img.sum() == out.sum()
 
         img = np.zeros((32, 32, 3))
-        consumer._redis_hash = None
+        consumer._redis_hash = 'not none'
         out = consumer.grpc_image(img, 'model', 1, model_shape, 'i', 'DT_HALF')
 
         assert (1,) + img.shape == out.shape

--- a/redis_consumer/consumers/image_consumer_test.py
+++ b/redis_consumer/consumers/image_consumer_test.py
@@ -324,6 +324,7 @@ class TestImageFileConsumer(object):
 
             def get_model_metadata(model_name, model_version):
                 return {
+                    'in_tensor_name': 'image',
                     'in_tensor_dtype': 'DT_FLOAT',
                     'in_tensor_shape': ','.join(str(s) for s in model_shape),
                 }

--- a/redis_consumer/consumers/image_consumer_test.py
+++ b/redis_consumer/consumers/image_consumer_test.py
@@ -323,11 +323,11 @@ class TestImageFileConsumer(object):
         def make_model_metadata_of_size(model_shape=(-1, 256, 256, 1)):
 
             def get_model_metadata(model_name, model_version):
-                return {
+                return [{
                     'in_tensor_name': 'image',
                     'in_tensor_dtype': 'DT_FLOAT',
                     'in_tensor_shape': ','.join(str(s) for s in model_shape),
-                }
+                }]
 
             return get_model_metadata
 

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -56,7 +56,6 @@ REDIS_PORT = config('REDIS_PORT', default=6379, cast=int)
 # TensorFlow Serving client connection
 TF_HOST = config('TF_HOST', default='tf-serving')
 TF_PORT = config('TF_PORT', default=8500, cast=int)
-TF_TENSOR_NAME = config('TF_TENSOR_NAME', default='image')
 # maximum batch allowed by TensorFlow Serving
 TF_MAX_BATCH_SIZE = config('TF_MAX_BATCH_SIZE', default=128, cast=int)
 # minimum expected model size, dynamically change batches proportionately.


### PR DESCRIPTION
The environment variable `TF_TENSOR_NAME` is now unnecessary, as that information is stored within the GetModelMetadata response.

However, the current `TensorFlowServingConsumer.predict` method is only built for single-input models. If they require more than one input, they will fail.

Fixes #95 