### PR TITLE
bump deepcell-toolbox to 0.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ dict-to-protobuf==0.0.3.9
 pytz==2019.1
 keras_retinanet==0.5.1
 deepcell-tracking==0.2.5
-deepcell-toolbox==0.2.0
+deepcell-toolbox==0.4.0


### PR DESCRIPTION
* Fixes bugs in `tile_image` and `untile_image`.
* Fixes `phase_preprocessing` for non-float data.
* Removes `fgbg` reference in `deep_watershed` postprocessing.