### PR TITLE
Change Storage client to use exponential backoff.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ The consumer is configured using environment variables. Please find a table of a
 | `REDIS_TIMEOUT` | Timeout for each Redis request, in seconds. | `3` |
 | `EMPTY_QUEUE_TIMEOUT` | Time to wait after finding an empty queue, in seconds. | `5` |
 | `DO_NOTHING_TIMEOUT` | Time to wait after finding an item that requires no work, in seconds. | `0.5` |
+| `STORAGE_MAX_BACKOFF` | Maximum time to wait before retrying a Storage request | `60` |
 | `EXPIRE_TIME` | Expire Redis items this many seconds after completion. | `3600` |
 | `METADATA_EXPIRE_TIME` | Expire cached model metadata after this many seconds. | `30` |
 | `TF_HOST` | The IP address or hostname of TensorFlow Serving. | `"tf-serving"` |

--- a/redis_consumer/consumers/base_consumer.py
+++ b/redis_consumer/consumers/base_consumer.py
@@ -572,13 +572,15 @@ class ZipFileConsumer(Consumer):
     def _upload_archived_images(self, hvalues, redis_hash):
         """Extract all image files and upload them to storage and redis"""
         all_hashes = set()
+        archive_uuid = uuid.uuid4().hex
         with utils.get_tempdir() as tempdir:
             fname = self.storage.download(hvalues.get('input_file_name'), tempdir)
             image_files = utils.get_image_files_from_dir(fname, tempdir)
             for i, imfile in enumerate(image_files):
+
                 clean_imfile = settings._strip(imfile.replace(tempdir, ''))
                 # Save each result channel as an image file
-                subdir = os.path.dirname(clean_imfile)
+                subdir = os.path.join(archive_uuid, os.path.dirname(clean_imfile))
                 dest, _ = self.storage.upload(imfile, subdir=subdir)
 
                 os.remove(imfile)  # remove the file to save some memory

--- a/redis_consumer/consumers/tracking_consumer.py
+++ b/redis_consumer/consumers/tracking_consumer.py
@@ -167,10 +167,11 @@ class TrackingConsumer(TensorFlowServingConsumer):
         self.logger.debug('tiffstack num_frames %s.', num_frames)
 
         with utils.get_tempdir() as tempdir:
+            uid = uuid.uuid4().hex
             for (i, img) in enumerate(tiff_stack):
                 # make a file name for this frame
-                segment_fname = '{}-tracking-frame-{}-{}.tif'.format(
-                    hvalues.get('original_name'), i, uuid.uuid4().hex)
+                segment_fname = '{}-{}-tracking-frame-{}.tif'.format(
+                    uid, hvalues.get('original_name'), i)
                 segment_local_path = os.path.join(tempdir, segment_fname)
 
                 # upload it

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -76,6 +76,7 @@ GRPC_RETRY_STATUSES = {
 REDIS_TIMEOUT = config('REDIS_TIMEOUT', default=3, cast=int)
 EMPTY_QUEUE_TIMEOUT = config('EMPTY_QUEUE_TIMEOUT', default=5, cast=int)
 DO_NOTHING_TIMEOUT = config('DO_NOTHING_TIMEOUT', default=0.5, cast=float)
+STORAGE_MAX_BACKOFF = config('STORAGE_MAX_BACKOFF', default=60, cast=float)
 
 # Cloud storage
 CLOUD_PROVIDER = config('CLOUD_PROVIDER', cast=str, default='gke').lower()

--- a/redis_consumer/storage.py
+++ b/redis_consumer/storage.py
@@ -44,7 +44,6 @@ from google.auth import exceptions as auth_exceptions
 import requests
 
 from redis_consumer import settings
-from redis_consumer.settings import DOWNLOAD_DIR
 
 
 class StorageException(Exception):
@@ -82,8 +81,8 @@ class Storage(object):
     """
 
     def __init__(self, bucket,
-                 download_dir=DOWNLOAD_DIR,
-                 max_backoff=60):
+                 download_dir=settings.DOWNLOAD_DIR,
+                 max_backoff=settings.STORAGE_MAX_BACKOFF):
         self.bucket = bucket
         self.download_dir = download_dir
         self.output_dir = 'output'

--- a/redis_consumer/storage.py
+++ b/redis_consumer/storage.py
@@ -150,7 +150,9 @@ class GoogleStorage(Storage):
         download_dir: path to local directory to save downloaded files
     """
 
-    def __init__(self, bucket, download_dir=DOWNLOAD_DIR, max_backoff=60):
+    def __init__(self, bucket,
+                 download_dir=settings.DOWNLOAD_DIR,
+                 max_backoff=settings.STORAGE_MAX_BACKOFF):
         super(GoogleStorage, self).__init__(bucket, download_dir, max_backoff)
         self.bucket_url = 'www.googleapis.com/storage/v1/b/{}/o'.format(bucket)
         self._network_errors = (
@@ -312,7 +314,9 @@ class S3Storage(Storage):
         download_dir: path to local directory to save downloaded files
     """
 
-    def __init__(self, bucket, download_dir=DOWNLOAD_DIR, max_backoff=60):
+    def __init__(self, bucket,
+                 download_dir=settings.DOWNLOAD_DIR,
+                 max_backoff=settings.STORAGE_MAX_BACKOFF):
         super(S3Storage, self).__init__(bucket, download_dir, max_backoff)
         self.bucket_url = 's3.amazonaws.com/{}'.format(bucket)
 

--- a/redis_consumer/storage_test.py
+++ b/redis_consumer/storage_test.py
@@ -113,8 +113,8 @@ def test_get_client():
 class TestStorage(object):
 
     def test_get_backoff(self):
-        maximum_backoff = 30
-        client = storage.Storage('bucket', maximum_backoff=maximum_backoff)
+        max_backoff = 30
+        client = storage.Storage('bucket', max_backoff=max_backoff)
         backoff = client.get_backoff(attempts=0)
         assert 1 < backoff < 2
 
@@ -122,7 +122,7 @@ class TestStorage(object):
         assert 8 < backoff < 9
 
         backoff = client.get_backoff(attempts=5)
-        assert backoff == maximum_backoff
+        assert backoff == max_backoff
 
     def test_get_download_path(self):
         with utils.get_tempdir() as tempdir:
@@ -147,7 +147,7 @@ class TestGoogleStorage(object):
                 bucket = 'test-bucket'
                 stg_cls = storage.GoogleStorage
                 stg_cls.get_storage_client = DummyGoogleClient
-                stg = stg_cls(bucket, tempdir, backoff=0)
+                stg = stg_cls(bucket, tempdir)
                 stg.get_backoff = lambda x: 0
                 url = stg.get_public_url(temp.name)
                 assert url == 'public-url'
@@ -166,7 +166,7 @@ class TestGoogleStorage(object):
                 bucket = 'test-bucket'
                 stg_cls = storage.GoogleStorage
                 stg_cls.get_storage_client = DummyGoogleClient
-                stg = stg_cls(bucket, tempdir, backoff=0)
+                stg = stg_cls(bucket, tempdir)
                 stg.get_backoff = lambda x: 0
 
                 # test succesful upload
@@ -190,7 +190,7 @@ class TestGoogleStorage(object):
             bucket = 'test-bucket'
             stg_cls = storage.GoogleStorage
             stg_cls.get_storage_client = DummyGoogleClient
-            stg = stg_cls(bucket, tempdir, backoff=0)
+            stg = stg_cls(bucket, tempdir)
             stg.get_backoff = lambda x: 0
 
             # test succesful download


### PR DESCRIPTION
Using exponential backoff is a best practice according to the GCS docs.

This PR removes the `backoff` argument to `Storage` classes, and replaces it with `max_backoff`, which defaults to the environment variable `STORAGE_MAX_BACKOFF`.

`Storage` clients will now keep track of the number of retries it has attempted and will calculate a backoff time that scales exponentially with the attempt count, instead of just being a constant backoff of `backoff` seconds.

The `ZipFileConsumer` has also been updated to upload the folder as `/output/<UUID>/typical/file/path.jpg`. This way the consumer does not overwrite old data with the same name, driving down the "update requests" which has a one request-per-second limit.

---

Fixes #108 