### PR TITLE
Improved testing coverage using fakeredis and pytest-mock

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,4 +15,4 @@ show_missing = True
 omit =
     **/*_test.py
     redis_consumer/pbs/*
-    redis_consumer/grpc_clients.py
+    redis_consumer/testing_utils.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: true
 dist: xenial
 
 git:
@@ -11,12 +10,13 @@ python:
   - 3.5
   - 3.6
   - 3.7
+  - 3.8
 
 cache: pip
 
 install:
   - travis_retry pip install -r requirements.txt
-  - travis_retry pip install pytest pytest-cov pytest-pep8 pytest-mock coveralls
+  - travis_retry pip install -r requirements-test.txt
   # install documentation requirements
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.7" ]]; then
       travis_retry pip install -r docs/rtd-requirements.txt;

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache: pip
 
 install:
   - travis_retry pip install -r requirements.txt
-  - travis_retry pip install pytest pytest-cov==2.5.1 pytest-pep8 coveralls
+  - travis_retry pip install pytest pytest-cov pytest-pep8 pytest-mock coveralls
   # install documentation requirements
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.7" ]]; then
       travis_retry pip install -r docs/rtd-requirements.txt;

--- a/redis_consumer/consumers/base_consumer.py
+++ b/redis_consumer/consumers/base_consumer.py
@@ -121,7 +121,7 @@ class Consumer(object):
             # Update redis with failed status
             self.update_key(redis_hash, {
                 'status': self.failed_status,
-                'reason': 'Invalid filetype for "%s" job.'.format(self.queue),
+                'reason': 'Invalid filetype for "{}" job.'.format(self.queue),
             })
 
     def _handle_error(self, err, redis_hash):

--- a/redis_consumer/consumers/base_consumer.py
+++ b/redis_consumer/consumers/base_consumer.py
@@ -496,9 +496,10 @@ class TensorFlowServingConsumer(Consumer):
 
         # TODO: generalize for more than a single input.
         if len(model_metadata) > 1:
-            raise ValueError('Model %s:%s has %s required inputs but was only '
-                             'given %s inputs.', model_name, model_version,
-                             len(model_metadata), len(image))
+            raise ValueError('Model {}:{} has {} required inputs but was only '
+                             'given {} inputs.'.format(
+                                 model_name, model_version,
+                                 len(model_metadata), len(image)))
         model_metadata = model_metadata[0]
 
         model_input_name = model_metadata['in_tensor_name']

--- a/redis_consumer/consumers/base_consumer_test.py
+++ b/redis_consumer/consumers/base_consumer_test.py
@@ -28,142 +28,18 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import copy
+import itertools
 import json
-import os
+import time
 
 import numpy as np
-from skimage.external import tifffile as tiff
 
 import pytest
 
 from redis_consumer import consumers
-from redis_consumer import utils
 from redis_consumer import settings
 
-
-def _get_image(img_h=300, img_w=300):
-    bias = np.random.rand(img_w, img_h) * 64
-    variance = np.random.rand(img_w, img_h) * (255 - 64)
-    img = np.random.rand(img_w, img_h) * variance + bias
-    return img
-
-
-class Bunch(object):
-    def __init__(self, **kwds):
-        self.__dict__.update(kwds)
-
-
-class DummyRedis(object):
-    # pylint: disable=W0613,R0201
-    def __init__(self, items=[], prefix='predict', status='new'):
-        self.work_queue = copy.copy(items)
-        self.processing_queue = []
-        self.prefix = '/'.join(x for x in prefix.split('/') if x)
-        self.status = status
-        self._redis_master = self
-        self.keys = [
-            '{}:{}:{}'.format(self.prefix, 'x.tiff', self.status),
-            '{}:{}:{}'.format(self.prefix, 'x.zip', 'other'),
-            '{}:{}:{}'.format('other', 'x.TIFF', self.status),
-            '{}:{}:{}'.format(self.prefix, 'x.ZIP', self.status),
-            '{}:{}:{}'.format(self.prefix, 'x.tiff', 'other'),
-            '{}:{}:{}'.format('other', 'x.zip', self.status),
-        ]
-
-    def rpoplpush(self, src, dst):
-        if src.startswith('processing'):
-            source = self.processing_queue
-            dest = self.work_queue
-        elif src.startswith(self.prefix):
-            source = self.work_queue
-            dest = self.processing_queue
-
-        try:
-            x = source.pop()
-            dest.insert(0, x)
-            return x
-        except IndexError:
-            return None
-
-    def lpush(self, name, *values):
-        self.work_queue = list(reversed(values)) + self.work_queue
-        return len(self.work_queue)
-
-    def lrem(self, name, count, value):
-        self.processing_queue.remove(value)
-        return count
-
-    def llen(self, queue):
-        if queue.startswith('processing'):
-            return len(self.processing_queue)
-        return len(self.work_queue)
-
-    def hmget(self, rhash, *args):
-        return [self.hget(rhash, a) for a in args]
-
-    def hmset(self, rhash, hvals):
-        return hvals
-
-    def expire(self, name, time):
-        return 1
-
-    def hget(self, rhash, field):
-        if field == 'status':
-            return rhash.split(':')[-1]
-        elif field == 'file_name':
-            return rhash.split(':')[1]
-        elif field == 'input_file_name':
-            return rhash.split(':')[1]
-        elif field == 'output_file_name':
-            return rhash.split(':')[1]
-        elif field == 'reason':
-            return 'reason'
-        return False
-
-    def hset(self, rhash, status, value):
-        return {status: value}
-
-    def hgetall(self, rhash):
-        return {
-            'model_name': 'model',
-            'model_version': '0',
-            'postprocess_function': '',
-            'preprocess_function': '',
-            'file_name': rhash.split(':')[1],
-            'input_file_name': rhash.split(':')[1],
-            'output_file_name': rhash.split(':')[1],
-            'status': rhash.split(':')[-1],
-            'children': 'predict:1.tiff:done,predict:2.tiff:failed,predict:3.tiff:new',
-            'children:done': 'predict:4.tiff:done,predict:5.tiff:done',
-            'children:failed': 'predict:6.tiff:failed,predict:7.tiff:failed',
-        }
-
-
-class DummyStorage(object):
-    # pylint: disable=W0613,R0201
-    def __init__(self, num=3):
-        self.num = num
-
-    def download(self, path, dest):
-        if path.lower().endswith('.zip'):
-            paths = []
-            for i in range(self.num):
-                img = _get_image()
-                base, ext = os.path.splitext(path)
-                _path = '{}{}{}'.format(base, i, ext)
-                tiff.imsave(os.path.join(dest, _path), img)
-                paths.append(_path)
-            return utils.zip_files(paths, dest)
-        img = _get_image()
-        tiff.imsave(os.path.join(dest, path), img)
-        return path
-
-    def upload(self, zip_path, subdir=None):
-        return True, True
-
-    def get_public_url(self, zip_path):
-        return True
+from redis_consumer.testing_utils import Bunch, DummyStorage, redis_client
 
 
 class TestConsumer(object):

--- a/redis_consumer/consumers/base_consumer_test.py
+++ b/redis_consumer/consumers/base_consumer_test.py
@@ -43,167 +43,162 @@ from redis_consumer.testing_utils import Bunch, DummyStorage, redis_client
 
 
 class TestConsumer(object):
-    # pylint: disable=R0201
-    def test_get_redis_hash(self):
-        settings.EMPTY_QUEUE_TIMEOUT = 0.01  # don't sleep too long
-
+    # pylint: disable=R0201,W0621
+    def test_get_redis_hash(self, mocker, redis_client):
+        mocker.patch.object(settings, 'EMPTY_QUEUE_TIMEOUT', 0.01)
         queue_name = 'q'
-        # test emtpy queue
-        items = []
-        redis_client = DummyRedis(items, prefix=queue_name)
         consumer = consumers.Consumer(redis_client, None, queue_name)
-        rhash = consumer.get_redis_hash()
-        assert rhash is None
 
-        # LLEN somehow gives stale data, should still be None
-        redis_client.llen = lambda x: 1
-        consumer = consumers.Consumer(redis_client, None, queue_name)
-        rhash = consumer.get_redis_hash()
-        assert rhash is None
+        # test emtpy queue
+        assert consumer.get_redis_hash() is None
 
         # test that invalid items are not processed and are removed.
-        items = ['item%s:file.tif:new' % x for x in range(1, 4)]
-        redis_client = DummyRedis(items, prefix=queue_name)
+        item = 'item to process'
+        redis_client.lpush(queue_name, item)
+        # is_valid_hash returns True by default
+        assert consumer.get_redis_hash() == item
+        assert redis_client.llen(consumer.processing_queue) == 1
+        assert redis_client.lpop(consumer.processing_queue) == item
+        # queue should be empty, get None again
+        assert consumer.get_redis_hash() is None
 
-        consumer = consumers.Consumer(redis_client, None, queue_name)
-        consumer.is_valid_hash = lambda x: x.startswith('item1')
+        # test invalid hash is failed and removed from queue
+        mocker.patch.object(consumer, 'is_valid_hash', return_value=False)
+        redis_client.lpush(queue_name, 'invalid')
+        assert consumer.get_redis_hash() is None  # invalid hash, returns None
+        # invalid has was removed from the processing queue
+        assert redis_client.llen(consumer.processing_queue) == 0
+        # invalid hash was not returend to the work queue
+        assert redis_client.llen(consumer.queue) == 0
 
-        rhash = consumer.get_redis_hash()
-        assert rhash == items[0]
-        assert not redis_client.work_queue
-        assert len(redis_client.processing_queue)
-        assert redis_client.processing_queue == [rhash]
+        # test llen returns 1 but item is gone by the time the pop happens
+        mocker.patch.object(redis_client, 'llen', lambda x: 1)
+        assert consumer.get_redis_hash() is None
 
-    def test_purge_processing_queue(self):
+    def test_purge_processing_queue(self, redis_client):
         queue_name = 'q'
-        items = []
-        redis_client = DummyRedis(items, prefix=queue_name)
+        keys = ['abc', 'def', 'xyz']
         consumer = consumers.Consumer(redis_client, None, queue_name)
+        # set keys in processing queue
+        for key in keys:
+            redis_client.lpush(consumer.processing_queue, key)
 
-        redis_client.processing_queue = list(range(5))
         consumer.purge_processing_queue()
-        assert not redis_client.processing_queue
 
-    def test_update_key(self):
-        global _redis_values
-        _redis_values = None
+        assert redis_client.llen(consumer.processing_queue) == 0
+        assert redis_client.llen(consumer.queue) == len(keys)
 
-        class _DummyRedis(object):
-            def hmset(self, _, hvals):
-                global _redis_values
-                _redis_values = hvals
-
-        consumer = consumers.Consumer(_DummyRedis(), None, 'q')
+    def test_update_key(self, redis_client):
+        consumer = consumers.Consumer(redis_client, None, 'q')
+        key = 'redis-hash'
         status = 'updated_status'
-        consumer.update_key('redis-hash', {
+        new_value = 'some value'
+        consumer.update_key(key, {
             'status': status,
-            'new_field': True
+            'new_field': new_value
         })
-        assert isinstance(_redis_values, dict)
-        assert 'status' in _redis_values and 'new_field' in _redis_values
-        assert _redis_values.get('status') == status
-        assert _redis_values.get('new_field') is True
+        redis_values = redis_client.hgetall(key)
+        assert redis_values.get('status') == status
+        assert redis_values.get('new_field') == new_value
 
         with pytest.raises(ValueError):
             consumer.update_key('redis-hash', 'data')
 
-    def test_handle_error(self):
-        global _redis_values
-        _redis_values = None
-
-        class _DummyRedis(object):
-            def hmset(self, _, hvals):
-                global _redis_values
-                _redis_values = hvals
-
-        consumer = consumers.Consumer(_DummyRedis(), None, 'q')
+    def test_handle_error(self, redis_client):
+        consumer = consumers.Consumer(redis_client, None, 'q')
         err = Exception('test exception')
-        consumer._handle_error(err, 'redis-hash')
-        assert isinstance(_redis_values, dict)
-        assert 'status' in _redis_values and 'reason' in _redis_values
-        assert _redis_values.get('status') == 'failed'
+        key = 'redis-hash'
+        consumer._handle_error(err, key)
 
-    def test__put_back_hash(self):
+        redis_values = redis_client.hgetall(key)
+        assert isinstance(redis_values, dict)
+        assert 'status' in redis_values and 'reason' in redis_values
+        assert redis_values.get('status') == 'failed'
+
+    def test__put_back_hash(self, redis_client):
         queue_name = 'q'
 
         # test emtpy queue
-        redis_client = DummyRedis([], prefix=queue_name)
         consumer = consumers.Consumer(redis_client, None, queue_name)
         consumer._put_back_hash('DNE')  # should be None, shows warning
 
         # put back the proper item
         item = 'redis_hash1'
-        redis_client.processing_queue = [item]
+        redis_client.lpush(consumer.processing_queue, item)
         consumer = consumers.Consumer(redis_client, None, queue_name)
         consumer._put_back_hash(item)
+        assert redis_client.llen(consumer.processing_queue) == 0
+        assert redis_client.llen(consumer.queue) == 1
+        assert redis_client.lpop(consumer.queue) == item
 
         # put back the wrong item
-        redis_client.processing_queue = [item, 'otherhash']
+        other = 'otherhash'
+        redis_client.lpush(consumer.processing_queue, other, item)
         consumer = consumers.Consumer(redis_client, None, queue_name)
         consumer._put_back_hash(item)
+        assert redis_client.llen(consumer.processing_queue) == 0
+        assert redis_client.llen(consumer.queue) == 2
+        assert redis_client.lpop(consumer.queue) == item
+        assert redis_client.lpop(consumer.queue) == other
 
-    def test_consume(self):
+    def test_consume(self, mocker, redis_client):
+        mocker.patch.object(settings, 'EMPTY_QUEUE_TIMEOUT', 0)
         queue_name = 'q'
-        items = ['{}:{}:{}.tiff'.format(queue_name, 'new', x) for x in range(1, 4)]
-        N = 1  # using a queue, only one key is processed per consume()
-        consumer = consumers.Consumer(
-            DummyRedis(items, prefix=queue_name), DummyStorage(), queue_name)
+        keys = [str(x) for x in range(1, 10)]
+        err = OSError('thrown on purpose')
+        i = 0
 
-        # test that _consume is called on each hash
-        global _processed
-        _processed = 0
+        consumer = consumers.Consumer(redis_client, DummyStorage(), queue_name)
 
-        def F(*_):
-            global _processed
-            _processed += 1
-            return 'done'
+        def throw_error(*_, **__):
+            raise err
 
-        consumer._consume = F
-        consumer.consume()
-        assert _processed == N
+        def finish(*_, **__):
+            return consumer.final_status
 
-        # error inside _consume calls _handle_error
-        consumer._consume = lambda x: 1 / 0
-        consumer._handle_error = F
-        consumer.consume()
-        assert _processed == N + 1
+        def fail(*_, **__):
+            return consumer.failed_status
+
+        def in_progress(*_, **__):
+            return 'another status'
 
         # empty redis queue
-        consumer.get_redis_hash = lambda: None
-        settings.EMPTY_QUEUE_TIMEOUT = 0.1  # don't sleep too long
+        spy = mocker.spy(time, 'sleep')
+        assert redis_client.llen(consumer.queue) == 0
         consumer.consume()
+        spy.assert_called_once_with(settings.EMPTY_QUEUE_TIMEOUT)
+
+        # OK now let's fill the queue
+        redis_client.lpush(consumer.queue, *keys)
+
+        # test that _consume is called on each hash
+        mocker.patch.object(consumer, '_consume', finish)
+        spy = mocker.spy(consumer, '_consume')
+        consumer.consume()
+        spy.assert_called_once_with(keys[i])
+        i += 1
+
+        # error inside _consume calls _handle_error
+        mocker.patch.object(consumer, '_consume', throw_error)
+        spy = mocker.spy(consumer, '_handle_error')
+        consumer.consume()
+        spy.assert_called_once_with(err, keys[i])
+        i += 1
+
+        # status is in progress calls sleep
+        mocker.patch.object(consumer, '_consume', in_progress)
+        spy = mocker.spy(consumer, '_put_back_hash')
+        consumer.consume()
+        spy.assert_called_with(keys[i])
+        i += 1
 
         # failed and done statuses call lrem
-        def lrem(key, count, value):
-            global _processed
-            _processed = True
-
-        _processed = False
-        redis_client = DummyRedis(items, prefix=queue_name)
-        redis_client.lrem = lrem
-        consumer = consumers.Consumer(redis_client, DummyStorage(), queue_name)
-        consumer.get_redis_hash = lambda: '%s:f.tiff:failed' % queue_name
-
-        consumer.consume()
-        assert _processed is True
-
-        _processed = False
-        consumer.get_redis_hash = lambda: '{q}:f.tiff:{status}'.format(
-            q=queue_name,
-            status=consumer.final_status)
-        consumer.consume()
-        assert _processed is True
-
-        _processed = 0
-
-        def G(*_):
-            global _processed
-            _processed += 1
-            return 'waiting'
-
-        consumer._consume = G
-        consumer.consume()
-        assert _processed == N
+        spy = mocker.spy(redis_client, 'lrem')
+        for status in (finish, fail):
+            mocker.patch.object(consumer, '_consume', status)
+            consumer.consume()
+            spy.assert_called_with(consumer.processing_queue, 1, keys[i])
+            i += 1
 
     def test__consume(self):
         with np.testing.assert_raises(NotImplementedError):
@@ -212,9 +207,8 @@ class TestConsumer(object):
 
 
 class TestTensorFlowServingConsumer(object):
-    # pylint: disable=R0201,W0613
-    def test__get_predict_client(self):
-        redis_client = DummyRedis([])
+    # pylint: disable=R0201,W0613,W0621
+    def test__get_predict_client(self, redis_client):
         consumer = consumers.TensorFlowServingConsumer(redis_client, None, 'q')
 
         with pytest.raises(ValueError):
@@ -222,8 +216,7 @@ class TestTensorFlowServingConsumer(object):
 
         consumer._get_predict_client('model_name', 1)
 
-    def test_grpc_image(self):
-        redis_client = DummyRedis([])
+    def test_grpc_image(self, redis_client):
         consumer = consumers.TensorFlowServingConsumer(redis_client, None, 'q')
         model_shape = (-1, 128, 128, 1)
 
@@ -247,8 +240,7 @@ class TestTensorFlowServingConsumer(object):
         assert (1,) + img.shape == out.shape
         assert img.sum() == out.sum()
 
-    def test_get_model_metadata(self):
-        redis_client = DummyRedis([])
+    def test_get_model_metadata(self, redis_client):
         model_shape = (-1, 216, 216, 1)
         model_dtype = 'DT_FLOAT'
         model_input_name = 'input_1'
@@ -356,9 +348,15 @@ class TestTensorFlowServingConsumer(object):
             consumer._get_predict_client = _get_bad_predict_client
             consumer.get_model_metadata('model', 1)
 
-    def test_predict(self):
-        redis_client = DummyRedis([])
+    def test_predict(self, mocker, redis_client):
+        model_shape = (-1, 128, 128, 1)
         consumer = consumers.TensorFlowServingConsumer(redis_client, None, 'q')
+
+        mocker.patch.object(consumer, 'get_model_metadata', lambda x, y: [{
+            'in_tensor_name': 'image',
+            'in_tensor_dtype': 'DT_HALF',
+            'in_tensor_shape': ','.join(str(s) for s in model_shape),
+        }])
 
         def grpc_image(data, *args, **kwargs):
             return data
@@ -366,42 +364,49 @@ class TestTensorFlowServingConsumer(object):
         def grpc_image_list(data, *args, **kwargs):  # pylint: disable=W0613
             return [data, data]
 
-        model_shape = (-1, 128, 128, 1)
-
         image_shapes = [
             (256, 256, 1),
             (128, 128, 1),
             (64, 64, 1),
             (100, 100, 1),
             (300, 300, 1),
+            (257, 301, 1),
+            (65, 127, 1),
         ]
+        grpc_funcs = (grpc_image, grpc_image_list)
+        untiles = (False, True)
+        prod = itertools.product(image_shapes, grpc_funcs, untiles)
 
-        for image_shape in image_shapes:
-            for grpc_func in (grpc_image, grpc_image_list):
-                for untile in (False, True):
+        for image_shape, grpc_func, untile in prod:
+            x = np.random.random(image_shape)
+            mocker.patch.object(consumer, 'grpc_image', grpc_func)
 
-                    x = np.random.random(image_shape)
-                    consumer.grpc_image = grpc_func
-                    consumer.get_model_metadata = lambda x, y: [{
-                        'in_tensor_name': 'image',
-                        'in_tensor_dtype': 'DT_HALF',
-                        'in_tensor_shape': ','.join(str(s) for s in model_shape),
-                    }]
+            consumer.predict(x, model_name='modelname', model_version=0,
+                             untile=untile)
 
-                    consumer.predict(x, model_name='modelname', model_version=0,
-                                     untile=untile)
+        # test mismatch of input data and model shape
+        with pytest.raises(ValueError):
+            x = np.random.random((5,))
+            consumer.predict(x, model_name='modelname', model_version=0)
+
+        # test multiple model metadata inputs are not supported
+        with pytest.raises(ValueError):
+            mocker.patch.object(consumer, 'get_model_metadata', grpc_image_list)
+            x = np.random.random((300, 300, 1))
+            consumer.predict(x, model_name='modelname', model_version=0)
 
 
 class TestZipFileConsumer(object):
-    # pylint: disable=R0201,W0613
-    def test_is_valid_hash(self):
-        items = ['item%s' % x for x in range(1, 4)]
+    # pylint: disable=R0201,W0613,W0621
+    def test_is_valid_hash(self, mocker, redis_client):
+        consumer = consumers.ZipFileConsumer(
+            redis_client, DummyStorage(), 'predict')
 
-        storage = DummyStorage()
-        redis_client = DummyRedis(items)
-        redis_client.hget = lambda *x: x[0]
+        def get_file_from_hash(redis_hash, _):
+            return redis_hash.split(':')[-1]
 
-        consumer = consumers.ZipFileConsumer(redis_client, storage, 'predict')
+        mocker.patch.object(redis_client, 'hget', get_file_from_hash)
+
         assert consumer.is_valid_hash(None) is False
         assert consumer.is_valid_hash('file.ZIp') is True
         assert consumer.is_valid_hash('predict:1234567890:file.ZIp') is True
@@ -410,132 +415,158 @@ class TestZipFileConsumer(object):
         assert consumer.is_valid_hash('predict:1234567890:file.tiff') is False
         assert consumer.is_valid_hash('predict:1234567890:file.png') is False
 
-    def test__upload_archived_images(self):
+    def test__upload_archived_images(self, mocker, redis_client):
         N = 3
-        items = ['item%s' % x for x in range(1, 4)]
-        redis_client = DummyRedis(items)
         storage = DummyStorage(num=N)
         consumer = consumers.ZipFileConsumer(redis_client, storage, 'predict')
-        hsh = consumer._upload_archived_images(
-            {'input_file_name': 'test.zip', 'children': ''},
-            'predict:redis_hash:f.zip')
+        # mocker.patch.object(consumer.storage, 'download')
+        hvalues = {'input_file_name': 'test.zip', 'children': 'none'}
+        redis_hash = 'predict:redis_hash:f.zip'
+        hsh = consumer._upload_archived_images(hvalues, redis_hash)
         assert len(hsh) == N
 
-    def test__upload_finished_children(self):
+    def test__upload_finished_children(self, mocker, redis_client):
         finished_children = ['predict:1.tiff', 'predict:2.zip', '']
         N = 3
-        items = ['item%s' % x for x in range(1, N + 1)]
-        redis_client = DummyRedis(items)
         storage = DummyStorage(num=N)
         consumer = consumers.ZipFileConsumer(redis_client, storage, 'predict')
+        mocker.patch.object(consumer, '_get_output_file_name', lambda x: x)
+
         path, url = consumer._upload_finished_children(
             finished_children, 'predict:redis_hash:f.zip')
         assert path and url
 
-    def test__get_output_file_name(self):
-        settings.GRPC_BACKOFF = 0
-        redis_client = DummyRedis([])
-        redis_client.ttl = lambda x: -1  # key is missing
-        redis_client._update_masters_and_slaves = lambda: True
+    def test__get_output_file_name(self, mocker, redis_client):
+        # TODO: bad coverage
+        mocker.patch.object(settings, 'GRPC_BACKOFF', 0)
+        storage = DummyStorage()
+        queue = 'q'
 
-        redis_client._redis_master = Bunch(hget=lambda x, y: None)
-        consumer = consumers.ZipFileConsumer(redis_client, None, 'predict')
+        consumer = consumers.ZipFileConsumer(redis_client, storage, queue)
 
+        # happy path
+        key = 'some key'
+        expected = 'output.zip'
+        redis_client.hset(key, 'output_file_name', expected)
+        assert consumer._get_output_file_name(key) == expected
+
+        # handling missing output file
+        key = 'key without output file'
+        spy = mocker.spy(redis_client, 'ttl')
+
+        # add key without output file but before it is expired
+        redis_client.hset(key, 'some field', 'some value')
         with pytest.raises(ValueError):
-            redis_client.ttl = lambda x: -2  # key is missing
-            consumer = consumers.ZipFileConsumer(redis_client, None, 'predict')
-            consumer._get_output_file_name('randomkey')
+            consumer._get_output_file_name(key)
+        assert spy.spy_return == -1
 
+        # expire key
+        redis_client.expire(key, 10)  # TTL should be -1
         with pytest.raises(ValueError):
-            redis_client.ttl = lambda x: 1  # key is expired
-            consumer = consumers.ZipFileConsumer(redis_client, None, 'predict')
-            consumer._get_output_file_name('randomkey')
+            consumer._get_output_file_name(key)
+        assert spy.spy_return == 10
 
+        # key does not exist
         with pytest.raises(ValueError):
-            redis_client.ttl = lambda x: -1  # key not expired
-            consumer = consumers.ZipFileConsumer(redis_client, None, 'predict')
-            consumer._get_output_file_name('randomkey')
+            consumer._get_output_file_name('randomkey')  # TTL should be -2
+        assert spy.spy_return == -2
 
-    def test__parse_failures(self):
+    def test__parse_failures(self, mocker, redis_client):
         N = 3
-        items = ['item%s' % x for x in range(1, N + 1)]
-        redis_client = DummyRedis(items)
         storage = DummyStorage(num=N)
+
+        keys = [str(x) for x in range(4)]
         consumer = consumers.ZipFileConsumer(redis_client, storage, 'predict')
+        for key in keys:
+            redis_client.lpush(consumer.queue, key)
+            redis_client.hset(key, 'reason', 'reason{}'.format(key))
+
+        spy = mocker.spy(redis_client, 'hget')
+        parsed = consumer._parse_failures(keys)
+        spy.assert_called_with(keys[-1], 'reason')
+        for key in keys:
+            assert '{0}=reason{0}'.format(key) in parsed
 
         # no failures
-        failed_children = ''
+        failed_children = ['']
         parsed = consumer._parse_failures(failed_children)
         assert parsed == ''
 
-        failed_children = ['item1', 'item2', '']
-        parsed = consumer._parse_failures(failed_children)
-        assert 'item1=reason' in parsed and 'item2=reason' in parsed
-
-    def test__cleanup(self):
+    def test__cleanup(self, mocker, redis_client):
         N = 3
         queue = 'predict'
-        items = ['item%s' % x for x in range(1, N + 1)]
-        redis_client = DummyRedis(items)
+        done = [str(i) for i in range(N)]
+        failed = [str(i) for i in range(N + 1, N * 2)]
         storage = DummyStorage(num=N)
         consumer = consumers.ZipFileConsumer(redis_client, storage, queue)
 
-        children = list('abcdef')
-        done = ['{}:done'.format(c) for c in children[:3]]
-        failed = ['{}:failed'.format(c) for c in children[3:]]
+        redis_hash = 'some job hash'
 
-        consumer._cleanup(items[0], children, done, failed)
+        mocker.patch.object(consumer, '_upload_finished_children',
+                            lambda *x: ('a', 'b'))
 
-        # test non-float values
-        redis_client = DummyRedis(items)
-        redis_client.hmget = lambda *args: ['x' for a in args]
-        consumer = consumers.ZipFileConsumer(redis_client, storage, queue)
-        consumer._cleanup(items[0], children, done, failed)
+        for item in done:
+            redis_client.hset(item, 'total_time', 1)  # summary field
+        for item in failed:
+            redis_client.hset(item, 'reason', 1)  # summary field
 
-    def test__consume(self):
+        children = done + failed
+
+        consumer._cleanup(redis_hash, children, done, failed)
+
+        assert redis_client.hget(redis_hash, 'total_jobs') == str(len(children))
+        for key in children:
+            assert redis_client.ttl(key) > 0  # all keys are expired
+
+    def test__consume(self, mocker, redis_client):
         N = 3
-        prefix = 'predict'
-        items = ['item%s' % x for x in range(1, 4)]
-        redis_client = DummyRedis(items)
         storage = DummyStorage(num=N)
+        children = list('abcdefg')
+        queue = 'q'
+        test_hash = 0
+        consumer = consumers.ZipFileConsumer(redis_client, storage, queue)
+
+        # test finished statuses are returned
+        for status in (consumer.failed_status, consumer.final_status, 'weird'):
+            test_hash += 1
+            redis_client.hset(test_hash, 'status', status)
+            result = consumer._consume(test_hash)
+            assert result == status
 
         # test `status` = "new"
-        status = 'new'
-        consumer = consumers.ZipFileConsumer(redis_client, storage, 'predict')
-        consumer._upload_archived_images = lambda x, y: items
-        dummyhash = '{queue}:{fname}.zip:{status}'.format(
-            queue=prefix, status=status, fname=status)
-        result = consumer._consume(dummyhash)
+        dummy = lambda *x: children
+        mocker.patch.object(consumer, '_cleanup', dummy)
+        mocker.patch.object(consumer, '_upload_archived_images', dummy)
+        mocker.patch.object(consumer, '_upload_finished_children', dummy)
+
+        test_hash += 1
+        redis_client.hset(test_hash, 'status', 'new')
+        result = consumer._consume(test_hash)
         assert result == 'waiting'
+        assert redis_client.hget(test_hash, 'children') == ','.join(children)
 
         # test `status` = "waiting"
         status = 'waiting'
-        consumer = consumers.ZipFileConsumer(redis_client, storage, 'predict')
-        dummyhash = '{queue}:{fname}.zip:{status}'.format(
-            queue=prefix, status=status, fname=status)
-        result = consumer._consume(dummyhash)
-        assert result == status
+        test_hash += 1
+        children = ['done', 'failed', 'waiting', 'move-to-done']
+        child_statuses = ['done', 'failed', 'waiting', 'done']
+        data = {'status': status, 'children': ','.join(children)}
+        redis_client.hmset(test_hash, data)
+        for child, child_status in zip(children, child_statuses):
+            redis_client.hset(child, 'status', child_status)
 
-        # test `status` = "done"
-        status = 'done'
-        consumer = consumers.ZipFileConsumer(redis_client, storage, 'predict')
-        dummyhash = '{queue}:{fname}.zip:{status}'.format(
-            queue=prefix, status=status, fname=status)
-        result = consumer._consume(dummyhash)
+        result = consumer._consume(test_hash)
         assert result == status
+        hvals = redis_client.hgetall(test_hash)
+        done_children = set(hvals.get('children:done', '').split(','))
+        assert done_children == {'done', 'move-to-done'}
+        assert hvals.get('children:failed') == 'failed'
 
-        # test `status` = "failed"
-        status = 'failed'
-        consumer = consumers.ZipFileConsumer(redis_client, storage, 'predict')
-        dummyhash = '{queue}:{fname}.zip:{status}'.format(
-            queue=prefix, status=status, fname=status)
-        result = consumer._consume(dummyhash)
-        assert result == status
-
-        # test `status` = "other-status"
-        status = 'other-status'
-        consumer = consumers.ZipFileConsumer(redis_client, storage, 'predict')
-        dummyhash = '{queue}:{fname}.zip:{status}'.format(
-            queue=prefix, status=status, fname=status)
-        result = consumer._consume(dummyhash)
-        assert result == status
+        # set the "waiting" child to "done"
+        redis_client.hset('waiting', 'status', consumer.final_status)
+        result = consumer._consume(test_hash)
+        assert result == consumer.final_status
+        hvals = redis_client.hgetall(test_hash)
+        done_children = set(hvals.get('children:done', '').split(','))
+        assert done_children == {'done', 'move-to-done', 'waiting'}
+        assert hvals.get('children:failed') == 'failed'

--- a/redis_consumer/consumers/image_consumer_test.py
+++ b/redis_consumer/consumers/image_consumer_test.py
@@ -40,15 +40,13 @@ from redis_consumer.testing_utils import DummyStorage, redis_client, _get_image
 
 
 class TestImageFileConsumer(object):
-    # pylint: disable=R0201
-    def test_is_valid_hash(self):
-        items = ['item%s' % x for x in range(1, 4)]
-
+    # pylint: disable=R0201,W0621
+    def test_is_valid_hash(self, mocker, redis_client):
         storage = DummyStorage()
-        redis_client = DummyRedis(items)
-        redis_client.hget = lambda *x: x[0]
+        mocker.patch.object(redis_client, 'hget', lambda x, y: x.split(':')[-1])
 
         consumer = consumers.ImageFileConsumer(redis_client, storage, 'predict')
+
         assert consumer.is_valid_hash(None) is False
         assert consumer.is_valid_hash('file.ZIp') is False
         assert consumer.is_valid_hash('predict:1234567890:file.ZIp') is False
@@ -57,15 +55,15 @@ class TestImageFileConsumer(object):
         assert consumer.is_valid_hash('predict:1234567890:file.tiff') is True
         assert consumer.is_valid_hash('predict:1234567890:file.png') is True
 
-    def test__get_processing_function(self):
-        _funcs = settings.PROCESSING_FUNCTIONS
-        settings.PROCESSING_FUNCTIONS = {
+    def test__get_processing_function(self, mocker, redis_client):
+        mocker.patch.object(settings, 'PROCESSING_FUNCTIONS', {
             'valid': {
                 'valid': lambda x: True
             }
-        }
+        })
 
-        consumer = consumers.ImageFileConsumer(None, None, 'q')
+        storage = DummyStorage()
+        consumer = consumers.ImageFileConsumer(redis_client, storage, 'q')
 
         x = consumer._get_processing_function('VaLiD', 'vAlId')
         y = consumer._get_processing_function('vAlId', 'VaLiD')
@@ -77,36 +75,52 @@ class TestImageFileConsumer(object):
         with pytest.raises(ValueError):
             consumer._get_processing_function('valid', 'invalid')
 
-        settings.PROCESSING_FUNCTIONS = _funcs
+    def test_process(self, mocker, redis_client):
+        # TODO: better test coverage
+        storage = DummyStorage()
+        queue = 'q'
+        img = np.random.random((1, 32, 32, 1))
 
-    def test_process(self):
-        _funcs = settings.PROCESSING_FUNCTIONS
-        settings.PROCESSING_FUNCTIONS = {
+        mocker.patch.object(settings, 'PROCESSING_FUNCTIONS', {
             'valid': {
-                'valid': lambda x: x
+                'valid': lambda x: x,
+                'retinanet': lambda *x: x[0],
+                'retinanet-semantic': lambda x: x,
             }
-        }
+        })
 
-        img = np.zeros((1, 32, 32, 1))
-        redis_client = DummyRedis([])
-        consumer = consumers.ImageFileConsumer(redis_client, None, 'q')
+        consumer = consumers.ImageFileConsumer(redis_client, storage, queue)
+
+        mocker.patch.object(consumer, '_redis_hash', 'a hash')
+
+        output = consumer.process(img, '', '')
+        np.testing.assert_equal(img, output)
+
+        # image is returned but channel squeezed out
         output = consumer.process(img, 'valid', 'valid')
-        assert img.shape[1:] == output.shape
+        np.testing.assert_equal(img[0], output)
 
-        settings.PROCESSING_FUNCTIONS = _funcs
+        img = np.random.random((2, 32, 32, 1))
+        output = consumer.process(img, 'retinanet-semantic', 'valid')
+        np.testing.assert_equal(img[0], output)
 
-    def test_detect_label(self):
+        consumer._rawshape = (21, 21)
+        img = np.random.random((1, 32, 32, 1))
+        output = consumer.process(img, 'retinanet', 'valid')
+        np.testing.assert_equal(img[0], output)
+
+    def test_detect_label(self, mocker, redis_client):
         # pylint: disable=W0613
-        redis_client = DummyRedis([])
         model_shape = (1, 216, 216, 1)
         consumer = consumers.ImageFileConsumer(redis_client, None, 'q')
-        consumer.get_model_metadata = lambda x, y: {
-            'in_tensor_dtype': 'DT_FLOAT',
-            'in_tensor_shape': ','.join(str(s) for s in model_shape),
-        }
-        image = _get_image(model_shape[1] * 2, model_shape[2] * 2)
 
-        settings.LABEL_DETECT_MODEL = 'dummymodel:1'
+        def dummy_metadata(*_, **__):
+            return {
+                'in_tensor_dtype': 'DT_FLOAT',
+                'in_tensor_shape': ','.join(str(s) for s in model_shape),
+            }
+
+        image = _get_image(model_shape[1] * 2, model_shape[2] * 2)
 
         def predict(*_, **__):
             data = np.zeros((3,))
@@ -114,69 +128,66 @@ class TestImageFileConsumer(object):
             data[i] = 1
             return data
 
-        consumer.predict = predict
+        mocker.patch.object(consumer, 'predict', predict)
+        mocker.patch.object(consumer, 'get_model_metadata', dummy_metadata)
+        mocker.patch.object(settings, 'LABEL_DETECT_MODEL', 'dummymodel:1')
 
-        settings.LABEL_DETECT_ENABLED = False
-
+        mocker.patch.object(settings, 'LABEL_DETECT_ENABLED', False)
         label = consumer.detect_label(image)
         assert label is None
 
-        settings.LABEL_DETECT_ENABLED = True
-
+        mocker.patch.object(settings, 'LABEL_DETECT_ENABLED', True)
         label = consumer.detect_label(image)
         assert label in set(list(range(4)))
 
-    def test_detect_scale(self):
+    def test_detect_scale(self, mocker, redis_client):
         # pylint: disable=W0613
-        redis_client = DummyRedis([])
-
+        # TODO: test rescale is < 1% of the original
         model_shape = (1, 216, 216, 1)
         consumer = consumers.ImageFileConsumer(redis_client, None, 'q')
-        consumer.get_model_metadata = lambda x, y: {
-            'in_tensor_dtype': 'DT_FLOAT',
-            'in_tensor_shape': ','.join(str(s) for s in model_shape),
-        }
+
+        def dummy_metadata(*_, **__):
+            return {
+                'in_tensor_dtype': 'DT_FLOAT',
+                'in_tensor_shape': ','.join(str(s) for s in model_shape),
+            }
+
         big_size = model_shape[1] * np.random.randint(2, 9)
         image = _get_image(big_size, big_size)
 
-        expected = (model_shape[1] / (big_size)) ** 2
+        expected = 1
 
-        settings.SCALE_DETECT_MODEL = 'dummymodel:1'
+        def predict(diff=1e-8):
+            def _predict(*_, **__):
+                sign = -1 if np.random.randint(1, 5) > 2 else 1
+                return expected + sign * diff
+            return _predict
 
-        def predict(*_, **__):
-            sign = -1 if np.random.randint(1, 5) > 2 else 1
-            return expected + sign * 1e-8  # small differences get averaged out
-
-        consumer.predict = predict
-
-        settings.SCALE_DETECT_ENABLED = False
-
+        mocker.patch.object(consumer, 'get_model_metadata', dummy_metadata)
+        mocker.patch.object(settings, 'SCALE_DETECT_ENABLED', False)
+        mocker.patch.object(settings, 'SCALE_DETECT_MODEL', 'dummymodel:1')
         scale = consumer.detect_scale(image)
         assert scale == 1
 
-        settings.SCALE_DETECT_ENABLED = True
-
-        consumer.predict = predict
-
+        mocker.patch.object(settings, 'SCALE_DETECT_ENABLED', True)
+        mocker.patch.object(consumer, 'predict', predict(1e-8))
         scale = consumer.detect_scale(image)
-        assert isinstance(scale, (float, int))
-        np.testing.assert_almost_equal(scale, expected)
+        # very small changes within error range:
+        assert scale == 1
 
-        # scale = consumer.detect_scale(np.expand_dims(image, axis=-1))
-        # assert isinstance(scale, (float, int))
-        # np.testing.assert_almost_equal(scale, expected)
+        mocker.patch.object(settings, 'SCALE_DETECT_ENABLED', True)
+        mocker.patch.object(consumer, 'predict', predict(1e-1))
+        scale = consumer.detect_scale(image)
+        assert isinstance(scale, float)
+        np.testing.assert_almost_equal(scale, expected, 1e-1)
 
-    def test__consume(self):
+    def test__consume(self, mocker, redis_client):
         # pylint: disable=W0613
         prefix = 'predict'
         status = 'new'
-        redis_client = DummyRedis(prefix, status)
         storage = DummyStorage()
 
         consumer = consumers.ImageFileConsumer(redis_client, storage, prefix)
-
-        def _handle_error(err, rhash):
-            raise err
 
         def grpc_image(data, *args, **kwargs):
             return data
@@ -186,12 +197,6 @@ class TestImageFileConsumer(object):
 
         def grpc_image_list(data, *args, **kwargs):  # pylint: disable=W0613
             return [data, data]
-
-        def detect_scale(_):
-            return 1
-
-        def detect_label(_):
-            return 0
 
         def make_model_metadata_of_size(model_shape=(-1, 256, 256, 1)):
 
@@ -204,63 +209,54 @@ class TestImageFileConsumer(object):
 
             return get_model_metadata
 
-        dummyhash = '{}:test.tiff:{}'.format(prefix, status)
+        mocker.patch.object(consumer, 'detect_label', lambda x: 1)
+        mocker.patch.object(consumer, 'detect_scale', lambda x: 1)
+        mocker.patch.object(settings, 'LABEL_DETECT_ENABLED', True)
 
+        grpc_funcs = (grpc_image, grpc_image_list)
         model_shapes = [
             (-1, 600, 600, 1),  # image too small, pad
             (-1, 300, 300, 1),  # image is exactly the right size
             (-1, 150, 150, 1),  # image too big, tile
         ]
 
-        consumer._handle_error = _handle_error
-        consumer.grpc_image = grpc_image
-        consumer.detect_scale = detect_scale
-        consumer.detect_label = detect_label
-
-        # consumer.grpc_image = grpc_image_multi
-        # consumer.get_model_metadata = make_model_metadata_of_size(model_shapes[0])
-        #
-        # result = consumer._consume(dummyhash)
-        # assert result == consumer.final_status
-        #
-        # # test with a finished hash
-        # result = consumer._consume('{}:test.tiff:{}'.format(prefix, 'done'))
-        # assert result == 'done'
-
-        for b in (False, True):
-            settings.SCALE_DETECT_ENABLED = settings.LABEL_DETECT_ENABLED = b
-            for model_shape in model_shapes:
-                for grpc_func in (grpc_image, grpc_image_list):
-
-                    consumer.grpc_image = grpc_func
-                    consumer.get_model_metadata = \
-                        make_model_metadata_of_size(model_shape)
-
-                    result = consumer._consume(dummyhash)
-                    assert result == consumer.final_status
-                    # test with a finished hash
-                    result = consumer._consume('{}:test.tiff:{}'.format(
-                        prefix, consumer.final_status))
-                    assert result == consumer.final_status
-
-        # test with model_name and model_version
-        redis_client.hgetall = lambda x: {
-            'model_name': 'model',
+        empty_data = {'input_file_name': 'file.tiff'}
+        full_data = {
+            'input_file_name': 'file.tiff',
             'model_version': '0',
-            'label': '0',
+            'model_name': 'model',
+            'label': '1',
             'scale': '1',
-            'postprocess_function': '',
-            'preprocess_function': '',
-            'file_name': 'test_image.tiff',
-            'input_file_name': 'test_image.tiff',
-            'output_file_name': 'test_image.tiff'
         }
-        redis_client.hmset = lambda x, y: True
-        consumer = consumers.ImageFileConsumer(redis_client, storage, prefix)
-        consumer._handle_error = _handle_error
-        consumer.detect_scale = detect_scale
-        consumer.detect_label = detect_label
-        consumer.get_model_metadata = make_model_metadata_of_size((1, 300, 300, 1))
-        consumer.grpc_image = grpc_image
-        result = consumer._consume(dummyhash)
-        assert result == consumer.final_status
+        label_no_model_data = full_data.copy()
+        label_no_model_data['model_name'] = ''
+
+        datasets = [empty_data, full_data, label_no_model_data]
+
+        test_hash = 0
+        # test finished statuses are returned
+        for status in (consumer.failed_status, consumer.final_status):
+            test_hash += 1
+            data = empty_data.copy()
+            data['status'] = status
+            redis_client.hmset(test_hash, data)
+            result = consumer._consume(test_hash)
+            assert result == status
+            result = redis_client.hget(test_hash, 'status')
+            assert result == status
+            test_hash += 1
+
+        prod = itertools.product(model_shapes, grpc_funcs, datasets)
+
+        for model_shape, grpc_func, data in prod:
+            metadata = make_model_metadata_of_size(model_shape)
+            mocker.patch.object(consumer, 'grpc_image', grpc_func)
+            mocker.patch.object(consumer, 'get_model_metadata', metadata)
+            mocker.patch.object(consumer, 'process', lambda *x: x[0])
+
+            redis_client.hmset(test_hash, data)
+            result = consumer._consume(test_hash)
+            assert result == consumer.final_status
+            result = redis_client.hget(test_hash, 'status')
+            assert result == consumer.final_status
+            test_hash += 1

--- a/redis_consumer/consumers/image_consumer_test.py
+++ b/redis_consumer/consumers/image_consumer_test.py
@@ -28,142 +28,15 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import os
-import copy
+import itertools
 
 import numpy as np
-from skimage.external import tifffile as tiff
 
 import pytest
 
 from redis_consumer import consumers
-from redis_consumer import utils
 from redis_consumer import settings
-
-
-def _get_image(img_h=300, img_w=300):
-    bias = np.random.rand(img_w, img_h) * 64
-    variance = np.random.rand(img_w, img_h) * (255 - 64)
-    img = np.random.rand(img_w, img_h) * variance + bias
-    return img
-
-
-class Bunch(object):
-    def __init__(self, **kwds):
-        self.__dict__.update(kwds)
-
-
-class DummyRedis(object):
-    # pylint: disable=R0201,W0613
-    def __init__(self, items=None, prefix='predict', status='new'):
-        items = [] if items is None else items
-        self.work_queue = copy.copy(items)
-        self.processing_queue = []
-        self.prefix = '/'.join(x for x in prefix.split('/') if x)
-        self.status = status
-        self._redis_master = self
-        self.keys = [
-            '{}:{}:{}'.format(self.prefix, 'x.tiff', self.status),
-            '{}:{}:{}'.format(self.prefix, 'x.zip', 'other'),
-            '{}:{}:{}'.format('other', 'x.TIFF', self.status),
-            '{}:{}:{}'.format(self.prefix, 'x.ZIP', self.status),
-            '{}:{}:{}'.format(self.prefix, 'x.tiff', 'other'),
-            '{}:{}:{}'.format('other', 'x.zip', self.status),
-        ]
-
-    def rpoplpush(self, src, dst):
-        if src.startswith('processing'):
-            source = self.processing_queue
-            dest = self.work_queue
-        elif src.startswith(self.prefix):
-            source = self.work_queue
-            dest = self.processing_queue
-
-        try:
-            x = source.pop()
-            dest.insert(0, x)
-            return x
-        except IndexError:
-            return None
-
-    def lpush(self, name, *values):
-        self.work_queue = list(reversed(values)) + self.work_queue
-        return len(self.work_queue)
-
-    def lrem(self, name, count, value):
-        self.processing_queue.remove(value)
-        return count
-
-    def llen(self, queue):
-        if queue.startswith('processing'):
-            return len(self.processing_queue)
-        return len(self.work_queue)
-
-    def hmget(self, rhash, *args):
-        return [self.hget(rhash, a) for a in args]
-
-    def hmset(self, rhash, hvals):  # pylint: disable=W0613
-        return hvals
-
-    def expire(self, name, time):  # pylint: disable=W0613
-        return 1
-
-    def hget(self, rhash, field):
-        if field == 'status':
-            return rhash.split(':')[-1]
-        elif field == 'file_name':
-            return rhash.split(':')[1]
-        elif field == 'input_file_name':
-            return rhash.split(':')[1]
-        elif field == 'output_file_name':
-            return rhash.split(':')[1]
-        elif field == 'reason':
-            return 'reason'
-        return False
-
-    def hset(self, rhash, status, value):  # pylint: disable=W0613
-        return {status: value}
-
-    def hgetall(self, rhash):  # pylint: disable=W0613
-        return {
-            'model_name': 'model',
-            'model_version': '0',
-            'postprocess_function': '',
-            'preprocess_function': '',
-            'file_name': rhash.split(':')[1],
-            'input_file_name': rhash.split(':')[1],
-            'output_file_name': rhash.split(':')[1],
-            'status': rhash.split(':')[-1],
-            'children': 'predict:1.tiff:done,predict:2.tiff:failed,predict:3.tiff:new',
-            'children:done': 'predict:4.tiff:done,predict:5.tiff:done',
-            'children:failed': 'predict:6.tiff:failed,predict:7.tiff:failed',
-        }
-
-
-class DummyStorage(object):
-    # pylint: disable=R0201,W0613
-    def __init__(self, num=3):
-        self.num = num
-
-    def download(self, path, dest):
-        if path.lower().endswith('.zip'):
-            paths = []
-            for i in range(self.num):
-                img = _get_image()
-                base, ext = os.path.splitext(path)
-                _path = '{}{}{}'.format(base, i, ext)
-                tiff.imsave(os.path.join(dest, _path), img)
-                paths.append(_path)
-            return utils.zip_files(paths, dest)
-        img = _get_image()
-        tiff.imsave(os.path.join(dest, path), img)
-        return path
-
-    def upload(self, zip_path, subdir=None):
-        return True, True
-
-    def get_public_url(self, zip_path):
-        return True
+from redis_consumer.testing_utils import DummyStorage, redis_client, _get_image
 
 
 class TestImageFileConsumer(object):

--- a/redis_consumer/consumers/tracking_consumer.py
+++ b/redis_consumer/consumers/tracking_consumer.py
@@ -232,10 +232,8 @@ class TrackingConsumer(TensorFlowServingConsumer):
                 if status == self.final_status:
                     # Segmentation is finished, save and load the frame.
                     with utils.get_tempdir() as tempdir:
-                        frame_zip = self.storage.download(
-                            self.redis.hget(segment_hash, 'output_file_name'),
-                            tempdir)
-
+                        out = self.redis.hget(segment_hash, 'output_file_name')
+                        frame_zip = self.storage.download(out, tempdir)
                         frame_files = list(utils.iter_image_archive(
                             frame_zip, tempdir))
 

--- a/redis_consumer/consumers/tracking_consumer_test.py
+++ b/redis_consumer/consumers/tracking_consumer_test.py
@@ -29,143 +29,18 @@ from __future__ import division
 from __future__ import print_function
 
 import os
-import copy
+import random
+import string
 
 import pytest
 
 import numpy as np
-from skimage.external import tifffile as tiff
+from skimage.external import tifffile
 
+import redis_consumer
 from redis_consumer import consumers
 from redis_consumer import settings
-from redis_consumer import utils
-
-
-def _get_image(img_h=300, img_w=300):
-    bias = np.random.rand(img_w, img_h) * 64
-    variance = np.random.rand(img_w, img_h) * (255 - 64)
-    img = np.random.rand(img_w, img_h) * variance + bias
-    return img
-
-
-class Bunch(object):
-    def __init__(self, **kwds):
-        self.__dict__.update(kwds)
-
-
-class DummyRedis(object):
-    # pylint: disable=R0201,W0613
-    def __init__(self, items=None, prefix='predict', status='new'):
-        items = [] if items is None else items
-        self.work_queue = copy.copy(items)
-        self.processing_queue = []
-        self.prefix = '/'.join(x for x in prefix.split('/') if x)
-        self.status = status
-        self._redis_master = self
-        self.keys = [
-            '{}:{}:{}'.format(self.prefix, 'x.tiff', self.status),
-            '{}:{}:{}'.format(self.prefix, 'x.zip', 'other'),
-            '{}:{}:{}'.format('other', 'x.TIFF', self.status),
-            '{}:{}:{}'.format(self.prefix, 'x.ZIP', self.status),
-            '{}:{}:{}'.format(self.prefix, 'x.tiff', 'other'),
-            '{}:{}:{}'.format('other', 'x.zip', self.status),
-        ]
-
-    def rpoplpush(self, src, dst):
-        if src.startswith('processing'):
-            source = self.processing_queue
-            dest = self.work_queue
-        elif src.startswith(self.prefix):
-            source = self.work_queue
-            dest = self.processing_queue
-
-        try:
-            x = source.pop()
-            dest.insert(0, x)
-            return x
-        except IndexError:
-            return None
-
-    def lpush(self, name, *values):
-        self.work_queue = list(reversed(values)) + self.work_queue
-        return len(self.work_queue)
-
-    def lrem(self, name, count, value):
-        self.processing_queue.remove(value)
-        return count
-
-    def llen(self, queue):
-        if queue.startswith('processing'):
-            return len(self.processing_queue)
-        return len(self.work_queue)
-
-    def hmget(self, rhash, *args):
-        return [self.hget(rhash, a) for a in args]
-
-    def hmset(self, rhash, hvals):  # pylint: disable=W0613
-        return hvals
-
-    def expire(self, name, time):  # pylint: disable=W0613
-        return 1
-
-    def hget(self, rhash, field):
-        if field == 'status':
-            return rhash.split(':')[-1]
-        elif field == 'file_name':
-            return rhash.split(':')[1]
-        elif field == 'input_file_name':
-            return rhash.split(':')[1]
-        elif field == 'output_file_name':
-            return rhash.split(':')[1]
-        elif field == 'reason':
-            return 'reason'
-        return False
-
-    def hset(self, rhash, status, value):  # pylint: disable=W0613
-        return {status: value}
-
-    def hgetall(self, rhash):  # pylint: disable=W0613
-        return {
-            'model_name': 'model',
-            'model_version': '0',
-            'field': '61',
-            'cuts': '0',
-            'postprocess_function': '',
-            'preprocess_function': '',
-            'file_name': rhash.split(':')[1],
-            'input_file_name': rhash.split(':')[1],
-            'output_file_name': rhash.split(':')[1],
-            'status': rhash.split(':')[-1],
-            'children': 'predict:1.tiff:done,predict:2.tiff:failed,predict:3.tiff:new',
-            'children:done': 'predict:4.tiff:done,predict:5.tiff:done',
-            'children:failed': 'predict:6.tiff:failed,predict:7.tiff:failed',
-        }
-
-
-class DummyStorage(object):
-    # pylint: disable=R0201,W0613
-    def __init__(self, num=3):
-        self.num = num
-
-    def download(self, path, dest):
-        if path.lower().endswith('.zip'):
-            paths = []
-            for i in range(self.num):
-                img = _get_image()
-                base, ext = os.path.splitext(path)
-                _path = '{}{}{}'.format(base, i, ext)
-                tiff.imsave(os.path.join(dest, _path), img)
-                paths.append(_path)
-            return utils.zip_files(paths, dest)
-        img = _get_image()
-        tiff.imsave(os.path.join(dest, path), img)
-        return path
-
-    def upload(self, zip_path, subdir=None):
-        return True, True
-
-    def get_public_url(self, zip_path):
-        return True
+from redis_consumer.testing_utils import DummyStorage, redis_client, _get_image
 
 
 class DummyTracker(object):

--- a/redis_consumer/redis_test.py
+++ b/redis_consumer/redis_test.py
@@ -23,96 +23,121 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ============================================================================
-"""Tests for Redis client wrapper class"""
+"""Tests for RedisClient wrapper class"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
 import random
+import time
 
+import fakeredis
 import redis
 import pytest
 
-import redis_consumer
+from redis_consumer.redis import RedisClient
 
 
-FAIL_COUNT = 0
+class WrappedFakeStrictRedis(fakeredis.FakeStrictRedis):
+    """Wrapper around fakeredis instance to mock errors and sentinel mode."""
 
+    def __init__(self, *_, **kwargs):
+        super(WrappedFakeStrictRedis, self).__init__(decode_responses='utf8')
+        self.should_fail = kwargs.get('should_fail', False)
 
-class DummyRedis(object):
-    def __init__(self, fail_tolerance=0, hard_fail=False, err=None):
-        self.fail_tolerance = fail_tolerance
-        self.hard_fail = hard_fail
-        if err is None:
-            err = redis.exceptions.ConnectionError('thrown on purpose')
-        self.err = err
-
-    def get_fail_count(self):
-        global FAIL_COUNT
-        if self.hard_fail:
-            raise AssertionError('thrown on purpose')
-        if FAIL_COUNT < self.fail_tolerance:
-            FAIL_COUNT += 1
-            raise self.err
-        return FAIL_COUNT
-
-    def sentinel_masters(self):
+    def sentinel_masters(self, *_, **__):
         return {'mymaster': {'ip': 'master', 'port': 6379}}
 
-    def sentinel_slaves(self, _):
-        n = random.randint(1, 4)
+    def sentinel_slaves(self, *_, **__):
+        n = random.randint(2, 5)
         return [{'ip': 'slave', 'port': 6379} for i in range(n)]
+
+    def busy_error(self, *_, **__):
+        if self.should_fail:
+            self.should_fail = False
+            raise redis.exceptions.ResponseError('BUSY SCRIPT KILL ERROR')
+        return True
+
+    def connect_error(self, *_, **__):
+        if self.should_fail:
+            self.should_fail = False
+            raise redis.exceptions.ConnectionError('thrown on purpose')
+        return True
+
+    def fail(self, *_, **__):
+        raise redis.exceptions.ResponseError('thrown on purpose')
 
 
 class TestRedis(object):
+    # pylint: disable=R0201
 
-    def test_redis_client(self):  # pylint: disable=R0201
-        global FAIL_COUNT
-
-        fails = random.randint(1, 3)
-        RedisClient = redis_consumer.redis.RedisClient
-
-        # monkey patch _get_redis_client function to use DummyRedis client
-        def _get_redis_client(*args, **kwargs):  # pylint: disable=W0613
-            return DummyRedis(fail_tolerance=fails)
-
-        RedisClient._get_redis_client = _get_redis_client
+    def test_successful_command(self, mocker):
+        mocker.patch('redis.StrictRedis', WrappedFakeStrictRedis)
+        mocker.patch('redis_consumer.redis.RedisClient.'
+                     '_update_masters_and_slaves')
 
         client = RedisClient(host='host', port='port', backoff=0)
-        assert client.get_fail_count() == fails
-        FAIL_COUNT = 0  # reset for the next test
 
+        # send some test requests using fakeredis
+        key = 'job_id'
+        values = {'data': str(random.randint(0, 100))}
+
+        client.hmset(key, values)  # Non-readonly
+        new_values = client.hgetall(key)
+
+        assert new_values == values
+
+        # test attribute error is thrown if invalid command.
         with pytest.raises(AttributeError):
             client.unknown_function()
 
-        # test ResponseError BUSY - should retry
-        def _get_redis_client_retry(*args, **kwargs):  # pylint: disable=W0613
-            err = redis.exceptions.ResponseError('BUSY SCRIPT KILL')
-            return DummyRedis(fail_tolerance=fails, err=err)
-
-        RedisClient._get_redis_client = _get_redis_client_retry
-
-        client = RedisClient(host='host', port='port', backoff=0)
-        assert client.get_fail_count() == fails
-        FAIL_COUNT = 0  # reset for the next test
-
-        # test ResponseError other - should fail
-        def _get_redis_client_err(*args, **kwargs):  # pylint: disable=W0613
-            err = redis.exceptions.ResponseError('OTHER ERROR')
-            return DummyRedis(fail_tolerance=fails, err=err)
-
-        RedisClient._get_redis_client = _get_redis_client_err
+    def test__update_masters_and_slaves(self, mocker):
+        mocker.patch('redis.StrictRedis', WrappedFakeStrictRedis)
         client = RedisClient(host='host', port='port', backoff=0)
 
+        master = client._redis_master
+        slaves = client._redis_slaves
+
+        # new master is same class but different instance.
+        assert isinstance(master, WrappedFakeStrictRedis)
+        assert isinstance(master, type(client._sentinel))
+        assert master is not client._sentinel
+
+        # starts with 1 slave, but should be 2 - 4 from mocked update.
+        assert len(slaves) > 1
+        for slave in slaves:
+            assert isinstance(slave, WrappedFakeStrictRedis)
+            assert isinstance(slave, type(client._sentinel))
+            assert slave is not client._sentinel
+
+        # test response error does not raise
+        def redis_response_error(*_, **__):
+            raise redis.exceptions.ResponseError('thrown on purpose')
+
+        mocker.patch('redis_consumer.redis.RedisClient._get_redis_client',
+                     redis_response_error)
+        client._update_masters_and_slaves()
+
+    def test_error_handling(self, mocker):
+        mocker.patch('redis.StrictRedis',
+                     lambda *_, **__: WrappedFakeStrictRedis(should_fail=True))
+        mocker.patch('redis_consumer.redis.RedisClient.'
+                     '_update_masters_and_slaves')
+
+        client = RedisClient(host='host', port='port', backoff=0)
         with pytest.raises(redis.exceptions.ResponseError):
-            client.get_fail_count()
+            client.fail()
 
-        # test that other exceptions will raise.
-        def _get_redis_client_bad(*args, **kwargs):  # pylint: disable=W0613
-            return DummyRedis(fail_tolerance=fails, hard_fail=True)
-
-        RedisClient._get_redis_client = _get_redis_client_bad
-
+        # mocked up ConnectionError
         client = RedisClient(host='host', port='port', backoff=0)
-        with pytest.raises(AssertionError):
-            client.get_fail_count()
+        spy = mocker.spy(client, '_update_masters_and_slaves')
+        response = client.connect_error()
+        assert response
+        spy.assert_called_once_with()
+
+        # mocked up retry-able ResponseError
+        client = RedisClient(host='host', port='port', backoff=0)
+        spy = mocker.spy(time, 'sleep')
+        response = client.busy_error()
+        assert response
+        spy.assert_called_once_with(client.backoff)

--- a/redis_consumer/storage.py
+++ b/redis_consumer/storage.py
@@ -38,9 +38,9 @@ import socket
 import urllib3
 
 import boto3
-from google.cloud import storage as google_storage
-from google.cloud import exceptions as google_exceptions
-from google.auth import exceptions as auth_exceptions
+import google.auth.exceptions
+import google.cloud.exceptions
+import google.cloud.storage
 import requests
 
 from redis_consumer import settings
@@ -157,16 +157,16 @@ class GoogleStorage(Storage):
         self.bucket_url = 'www.googleapis.com/storage/v1/b/{}/o'.format(bucket)
         self._network_errors = (
             socket.gaierror,
-            google_exceptions.TooManyRequests,
-            google_exceptions.InternalServerError,
-            google_exceptions.ServiceUnavailable,
-            google_exceptions.GatewayTimeout,
+            google.cloud.exceptions.TooManyRequests,
+            google.cloud.exceptions.InternalServerError,
+            google.cloud.exceptions.ServiceUnavailable,
+            google.cloud.exceptions.GatewayTimeout,
             urllib3.exceptions.MaxRetryError,
             urllib3.exceptions.NewConnectionError,
             requests.exceptions.ConnectionError,
             requests.exceptions.ReadTimeout,
-            auth_exceptions.RefreshError,
-            auth_exceptions.TransportError,
+            google.auth.exceptions.RefreshError,
+            google.auth.exceptions.TransportError,
         )
 
     def get_storage_client(self):
@@ -174,7 +174,7 @@ class GoogleStorage(Storage):
         attempts = 0
         while True:
             try:
-                return google_storage.Client()
+                return google.cloud.storage.Client()
             except OSError as err:
                 if attempts < 3:
                     backoff = self.get_backoff(attempts)

--- a/redis_consumer/storage_test.py
+++ b/redis_consumer/storage_test.py
@@ -237,7 +237,7 @@ class TestS3Storage(object):
 
     def test_upload(self, tmpdir, mocker):
         tmpdir = str(tmpdir)
-        mocker.patch('redis_consumer.storage.boto3.client', DummyS3Client)
+        mocker.patch('boto3.client', DummyS3Client)
         mocker.patch('redis_consumer.storage.S3Storage.get_backoff',
                      lambda *x: 0)
         with tempfile.NamedTemporaryFile(dir=tmpdir) as temp:
@@ -261,7 +261,7 @@ class TestS3Storage(object):
 
     def test_download(self, tmpdir, mocker):
         tmpdir = str(tmpdir)
-        mocker.patch('redis_consumer.storage.boto3.client', DummyS3Client)
+        mocker.patch('boto3.client', DummyS3Client)
         mocker.patch('redis_consumer.storage.S3Storage.get_backoff',
                      lambda *x: 0)
 

--- a/redis_consumer/storage_test.py
+++ b/redis_consumer/storage_test.py
@@ -148,8 +148,7 @@ class TestGoogleStorage(object):
         def bad_google_client():
             raise OSError('thrown on purpose')
 
-        mocker.patch('redis_consumer.storage.google_storage.Client',
-                     bad_google_client)
+        mocker.patch('google.cloud.storage.Client', bad_google_client)
         mocker.patch('redis_consumer.storage.GoogleStorage.get_backoff',
                      lambda *x: 0)
 
@@ -162,8 +161,7 @@ class TestGoogleStorage(object):
 
     def test_get_public_url(self, tmpdir, mocker):
         tmpdir = str(tmpdir)
-        mocker.patch('redis_consumer.storage.google_storage.Client',
-                     DummyGoogleClient)
+        mocker.patch('google.cloud.storage.Client', DummyGoogleClient)
         mocker.patch('redis_consumer.storage.GoogleStorage.get_backoff',
                      lambda *x: 0)
         with tempfile.NamedTemporaryFile(dir=tmpdir) as temp:
@@ -182,8 +180,7 @@ class TestGoogleStorage(object):
 
     def test_upload(self, tmpdir, mocker):
         tmpdir = str(tmpdir)
-        mocker.patch('redis_consumer.storage.google_storage.Client',
-                     DummyGoogleClient)
+        mocker.patch('google.cloud.storage.Client', DummyGoogleClient)
         mocker.patch('redis_consumer.storage.GoogleStorage.get_backoff',
                      lambda *x: 0)
         with tempfile.NamedTemporaryFile(dir=tmpdir) as temp:
@@ -210,8 +207,7 @@ class TestGoogleStorage(object):
         tmpdir = str(tmpdir)
 
         bucket = 'test-bucket'
-        mocker.patch('redis_consumer.storage.google_storage.Client',
-                     DummyGoogleClient)
+        mocker.patch('google.cloud.storage.Client', DummyGoogleClient)
         mocker.patch('redis_consumer.storage.GoogleStorage.get_backoff',
                      lambda *x: 0)
 

--- a/redis_consumer/testing_utils.py
+++ b/redis_consumer/testing_utils.py
@@ -1,0 +1,86 @@
+# Copyright 2016-2020 The Van Valen Lab at the California Institute of
+# Technology (Caltech), with support from the Paul Allen Family Foundation,
+# Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
+# All rights reserved.
+#
+# Licensed under a modified Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.github.com/vanvalenlab/kiosk-redis-consumer/LICENSE
+#
+# The Work provided may be used for non-commercial academic purposes only.
+# For any other use of the Work, including commercial use, please contact:
+# vanvalenlab@gmail.com
+#
+# Neither the name of Caltech nor the names of its contributors may be used
+# to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Common tests and fixtures for unit tests"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+
+import numpy as np
+from skimage.external import tifffile as tiff
+
+import pytest
+import fakeredis
+
+from redis_consumer import utils
+
+
+@pytest.fixture
+def redis_client():
+    client = fakeredis.FakeStrictRedis(decode_responses='utf8')
+    # patch the _redis_master field
+    client._redis_master = client
+    client._update_masters_and_slaves = lambda: True
+    yield client
+
+
+def _get_image(img_h=300, img_w=300):
+    bias = np.random.rand(img_w, img_h) * 64
+    variance = np.random.rand(img_w, img_h) * (255 - 64)
+    img = np.random.rand(img_w, img_h) * variance + bias
+    return img
+
+
+class Bunch(object):
+    def __init__(self, **kwds):
+        self.__dict__.update(kwds)
+
+
+class DummyStorage(object):
+    # pylint: disable=W0613,R0201
+    def __init__(self, num=3):
+        self.num = num
+
+    def download(self, path, dest):
+        if path.lower().endswith('.zip'):
+            paths = []
+            for i in range(self.num):
+                img = _get_image()
+                base, ext = os.path.splitext(path)
+                _path = '{}{}{}'.format(base, i, ext)
+                tiff.imsave(os.path.join(dest, _path), img)
+                paths.append(_path)
+            return utils.zip_files(paths, dest)
+        img = _get_image()
+        tiff.imsave(os.path.join(dest, path), img)
+        return path
+
+    def upload(self, zip_path, subdir=None):
+        return 'zip_path.zip', 'blob.public_url'
+
+    def get_public_url(self, zip_path):
+        return 'blob.public_url'

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,7 @@
+pytest
+pytest-cov
+pytest-mock
+pytest-pep8
+fakeredis
+six>=1.12
+coveralls

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 pytest
-pytest-cov
+pytest-cov==2.5.1
 pytest-mock
 pytest-pep8
 fakeredis


### PR DESCRIPTION
`pytest-mock` and `fakeredis` allow us to more directly patch the functions we need to patch instead of the less rigorous monkeypatching we had before. This PR pushes the consumer tests all up to nearly 100%, though I also removed the `grpc_clients` from the coverage ignore, so the coverage will not be changed much.

Also, common testing classes have been moved into the `testing_utils` file for better sharing among consumer tests.