### PR TITLE
Update MIBI consumer to inherit from ImageFileConsumer.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,4 +15,4 @@ show_missing = True
 omit =
     **/*_test.py
     redis_consumer/pbs/*
-    redis_consumer/grpc_clients.py
+    redis_consumer/testing_utils.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: true
 dist: xenial
 
 git:
@@ -11,12 +10,13 @@ python:
   - 3.5
   - 3.6
   - 3.7
+  - 3.8
 
 cache: pip
 
 install:
   - travis_retry pip install -r requirements.txt
-  - travis_retry pip install pytest pytest-cov==2.5.1 pytest-pep8 coveralls
+  - travis_retry pip install -r requirements-test.txt
   # install documentation requirements
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.7" ]]; then
       travis_retry pip install -r docs/rtd-requirements.txt;

--- a/redis_consumer/consumers/base_consumer.py
+++ b/redis_consumer/consumers/base_consumer.py
@@ -553,11 +553,9 @@ class TensorFlowServingConsumer(Consumer):
 
         return image
 
-    def save_output(self, image, redis_hash, fname, scale):
-        hvals = self.redis.hgetall(redis_hash)
+    def save_output(self, image, redis_hash, save_name, scale):
         with utils.get_tempdir() as tempdir:
             # Save each result channel as an image file
-            save_name = hvals.get('original_name', fname)
             subdir = os.path.dirname(save_name.replace(tempdir, ''))
             name = os.path.splitext(os.path.basename(save_name))[0]
 

--- a/redis_consumer/consumers/base_consumer.py
+++ b/redis_consumer/consumers/base_consumer.py
@@ -121,7 +121,7 @@ class Consumer(object):
             # Update redis with failed status
             self.update_key(redis_hash, {
                 'status': self.failed_status,
-                'reason': 'Invalid filetype for "%s" job.'.format(self.queue),
+                'reason': 'Invalid filetype for "{}" job.'.format(self.queue),
             })
 
     def _handle_error(self, err, redis_hash):
@@ -496,9 +496,10 @@ class TensorFlowServingConsumer(Consumer):
 
         # TODO: generalize for more than a single input.
         if len(model_metadata) > 1:
-            raise ValueError('Model %s:%s has %s required inputs but was only '
-                             'given %s inputs.', model_name, model_version,
-                             len(model_metadata), len(image))
+            raise ValueError('Model {}:{} has {} required inputs but was only '
+                             'given {} inputs.'.format(
+                                 model_name, model_version,
+                                 len(model_metadata), len(image)))
         model_metadata = model_metadata[0]
 
         model_input_name = model_metadata['in_tensor_name']

--- a/redis_consumer/consumers/base_consumer_test.py
+++ b/redis_consumer/consumers/base_consumer_test.py
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.github.com/vanvalenlab/kiosk-data-processing/LICENSE
+#     http://www.github.com/vanvalenlab/kiosk-redis-consumer/LICENSE
 #
 # The Work provided may be used for non-commercial academic purposes only.
 # For any other use of the Work, including commercial use, please contact:

--- a/redis_consumer/consumers/image_consumer.py
+++ b/redis_consumer/consumers/image_consumer.py
@@ -271,32 +271,8 @@ class ImageFileConsumer(TensorFlowServingConsumer):
         _ = timeit.default_timer()
         self.update_key(redis_hash, {'status': 'saving-results'})
 
-        with utils.get_tempdir() as tempdir:
-            # Save each result channel as an image file
-            save_name = hvals.get('original_name', fname)
-            subdir = os.path.dirname(save_name.replace(tempdir, ''))
-            name = os.path.splitext(os.path.basename(save_name))[0]
-
-            # Rescale image to original size before sending back to user
-            if isinstance(image, list):
-                outpaths = []
-                for i in image:
-                    outpaths.extend(utils.save_numpy_array(
-                        utils.rescale(i, 1 / scale), name=name,
-                        subdir=subdir, output_dir=tempdir))
-            else:
-                outpaths = utils.save_numpy_array(
-                    utils.rescale(image, 1 / scale), name=name,
-                    subdir=subdir, output_dir=tempdir)
-
-            # Save each prediction image as zip file
-            zip_file = utils.zip_files(outpaths, tempdir)
-
-            # Upload the zip file to cloud storage bucket
-            cleaned = zip_file.replace(tempdir, '')
-            subdir = os.path.dirname(settings._strip(cleaned))
-            subdir = subdir if subdir else None
-            dest, output_url = self.storage.upload(zip_file, subdir=subdir)
+        save_name = hvals.get('original_name', fname)
+        dest, output_url = self.save_output(image, redis_hash, save_name, scale)
 
         # Update redis with the final results
         t = timeit.default_timer() - start

--- a/redis_consumer/consumers/image_consumer_test.py
+++ b/redis_consumer/consumers/image_consumer_test.py
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.github.com/vanvalenlab/kiosk-data-processing/LICENSE
+#     http://www.github.com/vanvalenlab/kiosk-redis-consumer/LICENSE
 #
 # The Work provided may be used for non-commercial academic purposes only.
 # For any other use of the Work, including commercial use, please contact:

--- a/redis_consumer/consumers/image_consumer_test.py
+++ b/redis_consumer/consumers/image_consumer_test.py
@@ -28,154 +28,25 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import os
-import copy
+import itertools
 
 import numpy as np
-from skimage.external import tifffile as tiff
 
 import pytest
 
 from redis_consumer import consumers
-from redis_consumer import utils
 from redis_consumer import settings
-
-
-def _get_image(img_h=300, img_w=300):
-    bias = np.random.rand(img_w, img_h) * 64
-    variance = np.random.rand(img_w, img_h) * (255 - 64)
-    img = np.random.rand(img_w, img_h) * variance + bias
-    return img
-
-
-class Bunch(object):
-    def __init__(self, **kwds):
-        self.__dict__.update(kwds)
-
-
-class DummyRedis(object):
-    # pylint: disable=R0201,W0613
-    def __init__(self, items=None, prefix='predict', status='new'):
-        items = [] if items is None else items
-        self.work_queue = copy.copy(items)
-        self.processing_queue = []
-        self.prefix = '/'.join(x for x in prefix.split('/') if x)
-        self.status = status
-        self._redis_master = self
-        self.keys = [
-            '{}:{}:{}'.format(self.prefix, 'x.tiff', self.status),
-            '{}:{}:{}'.format(self.prefix, 'x.zip', 'other'),
-            '{}:{}:{}'.format('other', 'x.TIFF', self.status),
-            '{}:{}:{}'.format(self.prefix, 'x.ZIP', self.status),
-            '{}:{}:{}'.format(self.prefix, 'x.tiff', 'other'),
-            '{}:{}:{}'.format('other', 'x.zip', self.status),
-        ]
-
-    def rpoplpush(self, src, dst):
-        if src.startswith('processing'):
-            source = self.processing_queue
-            dest = self.work_queue
-        elif src.startswith(self.prefix):
-            source = self.work_queue
-            dest = self.processing_queue
-
-        try:
-            x = source.pop()
-            dest.insert(0, x)
-            return x
-        except IndexError:
-            return None
-
-    def lpush(self, name, *values):
-        self.work_queue = list(reversed(values)) + self.work_queue
-        return len(self.work_queue)
-
-    def lrem(self, name, count, value):
-        self.processing_queue.remove(value)
-        return count
-
-    def llen(self, queue):
-        if queue.startswith('processing'):
-            return len(self.processing_queue)
-        return len(self.work_queue)
-
-    def hmget(self, rhash, *args):
-        return [self.hget(rhash, a) for a in args]
-
-    def hmset(self, rhash, hvals):  # pylint: disable=W0613
-        return hvals
-
-    def expire(self, name, time):  # pylint: disable=W0613
-        return 1
-
-    def hget(self, rhash, field):
-        if field == 'status':
-            return rhash.split(':')[-1]
-        elif field == 'file_name':
-            return rhash.split(':')[1]
-        elif field == 'input_file_name':
-            return rhash.split(':')[1]
-        elif field == 'output_file_name':
-            return rhash.split(':')[1]
-        elif field == 'reason':
-            return 'reason'
-        return False
-
-    def hset(self, rhash, status, value):  # pylint: disable=W0613
-        return {status: value}
-
-    def hgetall(self, rhash):  # pylint: disable=W0613
-        return {
-            'model_name': 'model',
-            'model_version': '0',
-            'postprocess_function': '',
-            'preprocess_function': '',
-            'file_name': rhash.split(':')[1],
-            'input_file_name': rhash.split(':')[1],
-            'output_file_name': rhash.split(':')[1],
-            'status': rhash.split(':')[-1],
-            'children': 'predict:1.tiff:done,predict:2.tiff:failed,predict:3.tiff:new',
-            'children:done': 'predict:4.tiff:done,predict:5.tiff:done',
-            'children:failed': 'predict:6.tiff:failed,predict:7.tiff:failed',
-        }
-
-
-class DummyStorage(object):
-    # pylint: disable=R0201,W0613
-    def __init__(self, num=3):
-        self.num = num
-
-    def download(self, path, dest):
-        if path.lower().endswith('.zip'):
-            paths = []
-            for i in range(self.num):
-                img = _get_image()
-                base, ext = os.path.splitext(path)
-                _path = '{}{}{}'.format(base, i, ext)
-                tiff.imsave(os.path.join(dest, _path), img)
-                paths.append(_path)
-            return utils.zip_files(paths, dest)
-        img = _get_image()
-        tiff.imsave(os.path.join(dest, path), img)
-        return path
-
-    def upload(self, zip_path, subdir=None):
-        return True, True
-
-    def get_public_url(self, zip_path):
-        return True
+from redis_consumer.testing_utils import DummyStorage, redis_client, _get_image
 
 
 class TestImageFileConsumer(object):
-    # pylint: disable=R0201
-    def test_is_valid_hash(self):
-        items = ['item%s' % x for x in range(1, 4)]
-
+    # pylint: disable=R0201,W0621
+    def test_is_valid_hash(self, mocker, redis_client):
         storage = DummyStorage()
-        redis_client = DummyRedis(items)
-        redis_client.hget = lambda *x: x[0]
+        mocker.patch.object(redis_client, 'hget', lambda x, y: x.split(':')[-1])
 
         consumer = consumers.ImageFileConsumer(redis_client, storage, 'predict')
+
         assert consumer.is_valid_hash(None) is False
         assert consumer.is_valid_hash('file.ZIp') is False
         assert consumer.is_valid_hash('predict:1234567890:file.ZIp') is False
@@ -184,15 +55,15 @@ class TestImageFileConsumer(object):
         assert consumer.is_valid_hash('predict:1234567890:file.tiff') is True
         assert consumer.is_valid_hash('predict:1234567890:file.png') is True
 
-    def test__get_processing_function(self):
-        _funcs = settings.PROCESSING_FUNCTIONS
-        settings.PROCESSING_FUNCTIONS = {
+    def test__get_processing_function(self, mocker, redis_client):
+        mocker.patch.object(settings, 'PROCESSING_FUNCTIONS', {
             'valid': {
                 'valid': lambda x: True
             }
-        }
+        })
 
-        consumer = consumers.ImageFileConsumer(None, None, 'q')
+        storage = DummyStorage()
+        consumer = consumers.ImageFileConsumer(redis_client, storage, 'q')
 
         x = consumer._get_processing_function('VaLiD', 'vAlId')
         y = consumer._get_processing_function('vAlId', 'VaLiD')
@@ -204,36 +75,52 @@ class TestImageFileConsumer(object):
         with pytest.raises(ValueError):
             consumer._get_processing_function('valid', 'invalid')
 
-        settings.PROCESSING_FUNCTIONS = _funcs
+    def test_process(self, mocker, redis_client):
+        # TODO: better test coverage
+        storage = DummyStorage()
+        queue = 'q'
+        img = np.random.random((1, 32, 32, 1))
 
-    def test_process(self):
-        _funcs = settings.PROCESSING_FUNCTIONS
-        settings.PROCESSING_FUNCTIONS = {
+        mocker.patch.object(settings, 'PROCESSING_FUNCTIONS', {
             'valid': {
-                'valid': lambda x: x
+                'valid': lambda x: x,
+                'retinanet': lambda *x: x[0],
+                'retinanet-semantic': lambda x: x,
             }
-        }
+        })
 
-        img = np.zeros((1, 32, 32, 1))
-        redis_client = DummyRedis([])
-        consumer = consumers.ImageFileConsumer(redis_client, None, 'q')
+        consumer = consumers.ImageFileConsumer(redis_client, storage, queue)
+
+        mocker.patch.object(consumer, '_redis_hash', 'a hash')
+
+        output = consumer.process(img, '', '')
+        np.testing.assert_equal(img, output)
+
+        # image is returned but channel squeezed out
         output = consumer.process(img, 'valid', 'valid')
-        assert img.shape[1:] == output.shape
+        np.testing.assert_equal(img[0], output)
 
-        settings.PROCESSING_FUNCTIONS = _funcs
+        img = np.random.random((2, 32, 32, 1))
+        output = consumer.process(img, 'retinanet-semantic', 'valid')
+        np.testing.assert_equal(img[0], output)
 
-    def test_detect_label(self):
+        consumer._rawshape = (21, 21)
+        img = np.random.random((1, 32, 32, 1))
+        output = consumer.process(img, 'retinanet', 'valid')
+        np.testing.assert_equal(img[0], output)
+
+    def test_detect_label(self, mocker, redis_client):
         # pylint: disable=W0613
-        redis_client = DummyRedis([])
         model_shape = (1, 216, 216, 1)
         consumer = consumers.ImageFileConsumer(redis_client, None, 'q')
-        consumer.get_model_metadata = lambda x, y: {
-            'in_tensor_dtype': 'DT_FLOAT',
-            'in_tensor_shape': ','.join(str(s) for s in model_shape),
-        }
-        image = _get_image(model_shape[1] * 2, model_shape[2] * 2)
 
-        settings.LABEL_DETECT_MODEL = 'dummymodel:1'
+        def dummy_metadata(*_, **__):
+            return {
+                'in_tensor_dtype': 'DT_FLOAT',
+                'in_tensor_shape': ','.join(str(s) for s in model_shape),
+            }
+
+        image = _get_image(model_shape[1] * 2, model_shape[2] * 2)
 
         def predict(*_, **__):
             data = np.zeros((3,))
@@ -241,69 +128,66 @@ class TestImageFileConsumer(object):
             data[i] = 1
             return data
 
-        consumer.predict = predict
+        mocker.patch.object(consumer, 'predict', predict)
+        mocker.patch.object(consumer, 'get_model_metadata', dummy_metadata)
+        mocker.patch.object(settings, 'LABEL_DETECT_MODEL', 'dummymodel:1')
 
-        settings.LABEL_DETECT_ENABLED = False
-
+        mocker.patch.object(settings, 'LABEL_DETECT_ENABLED', False)
         label = consumer.detect_label(image)
         assert label is None
 
-        settings.LABEL_DETECT_ENABLED = True
-
+        mocker.patch.object(settings, 'LABEL_DETECT_ENABLED', True)
         label = consumer.detect_label(image)
         assert label in set(list(range(4)))
 
-    def test_detect_scale(self):
+    def test_detect_scale(self, mocker, redis_client):
         # pylint: disable=W0613
-        redis_client = DummyRedis([])
-
+        # TODO: test rescale is < 1% of the original
         model_shape = (1, 216, 216, 1)
         consumer = consumers.ImageFileConsumer(redis_client, None, 'q')
-        consumer.get_model_metadata = lambda x, y: {
-            'in_tensor_dtype': 'DT_FLOAT',
-            'in_tensor_shape': ','.join(str(s) for s in model_shape),
-        }
+
+        def dummy_metadata(*_, **__):
+            return {
+                'in_tensor_dtype': 'DT_FLOAT',
+                'in_tensor_shape': ','.join(str(s) for s in model_shape),
+            }
+
         big_size = model_shape[1] * np.random.randint(2, 9)
         image = _get_image(big_size, big_size)
 
-        expected = (model_shape[1] / (big_size)) ** 2
+        expected = 1
 
-        settings.SCALE_DETECT_MODEL = 'dummymodel:1'
+        def predict(diff=1e-8):
+            def _predict(*_, **__):
+                sign = -1 if np.random.randint(1, 5) > 2 else 1
+                return expected + sign * diff
+            return _predict
 
-        def predict(*_, **__):
-            sign = -1 if np.random.randint(1, 5) > 2 else 1
-            return expected + sign * 1e-8  # small differences get averaged out
-
-        consumer.predict = predict
-
-        settings.SCALE_DETECT_ENABLED = False
-
+        mocker.patch.object(consumer, 'get_model_metadata', dummy_metadata)
+        mocker.patch.object(settings, 'SCALE_DETECT_ENABLED', False)
+        mocker.patch.object(settings, 'SCALE_DETECT_MODEL', 'dummymodel:1')
         scale = consumer.detect_scale(image)
         assert scale == 1
 
-        settings.SCALE_DETECT_ENABLED = True
-
-        consumer.predict = predict
-
+        mocker.patch.object(settings, 'SCALE_DETECT_ENABLED', True)
+        mocker.patch.object(consumer, 'predict', predict(1e-8))
         scale = consumer.detect_scale(image)
-        assert isinstance(scale, (float, int))
-        np.testing.assert_almost_equal(scale, expected)
+        # very small changes within error range:
+        assert scale == 1
 
-        # scale = consumer.detect_scale(np.expand_dims(image, axis=-1))
-        # assert isinstance(scale, (float, int))
-        # np.testing.assert_almost_equal(scale, expected)
+        mocker.patch.object(settings, 'SCALE_DETECT_ENABLED', True)
+        mocker.patch.object(consumer, 'predict', predict(1e-1))
+        scale = consumer.detect_scale(image)
+        assert isinstance(scale, float)
+        np.testing.assert_almost_equal(scale, expected, 1e-1)
 
-    def test__consume(self):
+    def test__consume(self, mocker, redis_client):
         # pylint: disable=W0613
         prefix = 'predict'
         status = 'new'
-        redis_client = DummyRedis(prefix, status)
         storage = DummyStorage()
 
         consumer = consumers.ImageFileConsumer(redis_client, storage, prefix)
-
-        def _handle_error(err, rhash):
-            raise err
 
         def grpc_image(data, *args, **kwargs):
             return data
@@ -313,12 +197,6 @@ class TestImageFileConsumer(object):
 
         def grpc_image_list(data, *args, **kwargs):  # pylint: disable=W0613
             return [data, data]
-
-        def detect_scale(_):
-            return 1
-
-        def detect_label(_):
-            return 0
 
         def make_model_metadata_of_size(model_shape=(-1, 256, 256, 1)):
 
@@ -331,63 +209,54 @@ class TestImageFileConsumer(object):
 
             return get_model_metadata
 
-        dummyhash = '{}:test.tiff:{}'.format(prefix, status)
+        mocker.patch.object(consumer, 'detect_label', lambda x: 1)
+        mocker.patch.object(consumer, 'detect_scale', lambda x: 1)
+        mocker.patch.object(settings, 'LABEL_DETECT_ENABLED', True)
 
+        grpc_funcs = (grpc_image, grpc_image_list)
         model_shapes = [
             (-1, 600, 600, 1),  # image too small, pad
             (-1, 300, 300, 1),  # image is exactly the right size
             (-1, 150, 150, 1),  # image too big, tile
         ]
 
-        consumer._handle_error = _handle_error
-        consumer.grpc_image = grpc_image
-        consumer.detect_scale = detect_scale
-        consumer.detect_label = detect_label
-
-        # consumer.grpc_image = grpc_image_multi
-        # consumer.get_model_metadata = make_model_metadata_of_size(model_shapes[0])
-        #
-        # result = consumer._consume(dummyhash)
-        # assert result == consumer.final_status
-        #
-        # # test with a finished hash
-        # result = consumer._consume('{}:test.tiff:{}'.format(prefix, 'done'))
-        # assert result == 'done'
-
-        for b in (False, True):
-            settings.SCALE_DETECT_ENABLED = settings.LABEL_DETECT_ENABLED = b
-            for model_shape in model_shapes:
-                for grpc_func in (grpc_image, grpc_image_list):
-
-                    consumer.grpc_image = grpc_func
-                    consumer.get_model_metadata = \
-                        make_model_metadata_of_size(model_shape)
-
-                    result = consumer._consume(dummyhash)
-                    assert result == consumer.final_status
-                    # test with a finished hash
-                    result = consumer._consume('{}:test.tiff:{}'.format(
-                        prefix, consumer.final_status))
-                    assert result == consumer.final_status
-
-        # test with model_name and model_version
-        redis_client.hgetall = lambda x: {
-            'model_name': 'model',
+        empty_data = {'input_file_name': 'file.tiff'}
+        full_data = {
+            'input_file_name': 'file.tiff',
             'model_version': '0',
-            'label': '0',
+            'model_name': 'model',
+            'label': '1',
             'scale': '1',
-            'postprocess_function': '',
-            'preprocess_function': '',
-            'file_name': 'test_image.tiff',
-            'input_file_name': 'test_image.tiff',
-            'output_file_name': 'test_image.tiff'
         }
-        redis_client.hmset = lambda x, y: True
-        consumer = consumers.ImageFileConsumer(redis_client, storage, prefix)
-        consumer._handle_error = _handle_error
-        consumer.detect_scale = detect_scale
-        consumer.detect_label = detect_label
-        consumer.get_model_metadata = make_model_metadata_of_size((1, 300, 300, 1))
-        consumer.grpc_image = grpc_image
-        result = consumer._consume(dummyhash)
-        assert result == consumer.final_status
+        label_no_model_data = full_data.copy()
+        label_no_model_data['model_name'] = ''
+
+        datasets = [empty_data, full_data, label_no_model_data]
+
+        test_hash = 0
+        # test finished statuses are returned
+        for status in (consumer.failed_status, consumer.final_status):
+            test_hash += 1
+            data = empty_data.copy()
+            data['status'] = status
+            redis_client.hmset(test_hash, data)
+            result = consumer._consume(test_hash)
+            assert result == status
+            result = redis_client.hget(test_hash, 'status')
+            assert result == status
+            test_hash += 1
+
+        prod = itertools.product(model_shapes, grpc_funcs, datasets)
+
+        for model_shape, grpc_func, data in prod:
+            metadata = make_model_metadata_of_size(model_shape)
+            mocker.patch.object(consumer, 'grpc_image', grpc_func)
+            mocker.patch.object(consumer, 'get_model_metadata', metadata)
+            mocker.patch.object(consumer, 'process', lambda *x: x[0])
+
+            redis_client.hmset(test_hash, data)
+            result = consumer._consume(test_hash)
+            assert result == consumer.final_status
+            result = redis_client.hget(test_hash, 'status')
+            assert result == consumer.final_status
+            test_hash += 1

--- a/redis_consumer/consumers/mibi_consumer.py
+++ b/redis_consumer/consumers/mibi_consumer.py
@@ -132,7 +132,8 @@ class MibiConsumer(TensorFlowServingConsumer):
         _ = timeit.default_timer()
         self.update_key(redis_hash, {'status': 'saving-results'})
 
-        dest, output_url = self.save_output(image, redis_hash, fname, scale)
+        save_name = hvals.get('original_name', fname)
+        dest, output_url = self.save_output(image, redis_hash, save_name, scale)
 
         # Update redis with the final results
         t = timeit.default_timer() - start

--- a/redis_consumer/consumers/mibi_consumer_test.py
+++ b/redis_consumer/consumers/mibi_consumer_test.py
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.github.com/vanvalenlab/kiosk-data-processing/LICENSE
+#     http://www.github.com/vanvalenlab/kiosk-redis-consumer/LICENSE
 #
 # The Work provided may be used for non-commercial academic purposes only.
 # For any other use of the Work, including commercial use, please contact:
@@ -23,13 +23,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ============================================================================
-"""Tests for post-processing functions"""
+"""Tests for MibiConsumer"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import itertools
 import os
-import copy
 
 import numpy as np
 from skimage.external import tifffile as tiff
@@ -37,143 +37,15 @@ from skimage.external import tifffile as tiff
 import pytest
 
 from redis_consumer import consumers
-from redis_consumer import utils
-from redis_consumer import settings
-
-
-def _get_image(frames=2, img_h=256, img_w=256):
-    bias = np.random.rand(img_w, img_h) * 64
-    variance = np.random.rand(img_w, img_h) * (255 - 64)
-    img = np.random.rand(frames, img_w, img_h) * variance + bias
-    return img
-
-
-class Bunch(object):
-    def __init__(self, **kwds):
-        self.__dict__.update(kwds)
-
-
-class DummyRedis(object):
-    # pylint: disable=R0201,W0613
-    def __init__(self, items=None, prefix='predict', status='new'):
-        items = [] if items is None else items
-        self.work_queue = copy.copy(items)
-        self.processing_queue = []
-        self.prefix = '/'.join(x for x in prefix.split('/') if x)
-        self.status = status
-        self._redis_master = self
-        self.keys = [
-            '{}:{}:{}'.format(self.prefix, 'x.tiff', self.status),
-            '{}:{}:{}'.format(self.prefix, 'x.zip', 'other'),
-            '{}:{}:{}'.format('other', 'x.TIFF', self.status),
-            '{}:{}:{}'.format(self.prefix, 'x.ZIP', self.status),
-            '{}:{}:{}'.format(self.prefix, 'x.tiff', 'other'),
-            '{}:{}:{}'.format('other', 'x.zip', self.status),
-        ]
-
-    def rpoplpush(self, src, dst):
-        if src.startswith('processing'):
-            source = self.processing_queue
-            dest = self.work_queue
-        elif src.startswith(self.prefix):
-            source = self.work_queue
-            dest = self.processing_queue
-
-        try:
-            x = source.pop()
-            dest.insert(0, x)
-            return x
-        except IndexError:
-            return None
-
-    def lpush(self, name, *values):
-        self.work_queue = list(reversed(values)) + self.work_queue
-        return len(self.work_queue)
-
-    def lrem(self, name, count, value):
-        self.processing_queue.remove(value)
-        return count
-
-    def llen(self, queue):
-        if queue.startswith('processing'):
-            return len(self.processing_queue)
-        return len(self.work_queue)
-
-    def hmget(self, rhash, *args):
-        return [self.hget(rhash, a) for a in args]
-
-    def hmset(self, rhash, hvals):  # pylint: disable=W0613
-        return hvals
-
-    def expire(self, name, time):  # pylint: disable=W0613
-        return 1
-
-    def hget(self, rhash, field):
-        if field == 'status':
-            return rhash.split(':')[-1]
-        elif field == 'file_name':
-            return rhash.split(':')[1]
-        elif field == 'input_file_name':
-            return rhash.split(':')[1]
-        elif field == 'output_file_name':
-            return rhash.split(':')[1]
-        elif field == 'reason':
-            return 'reason'
-        return False
-
-    def hset(self, rhash, status, value):  # pylint: disable=W0613
-        return {status: value}
-
-    def hgetall(self, rhash):  # pylint: disable=W0613
-        return {
-            'model_name': 'model',
-            'model_version': '0',
-            'postprocess_function': '',
-            'preprocess_function': '',
-            'file_name': rhash.split(':')[1],
-            'input_file_name': rhash.split(':')[1],
-            'output_file_name': rhash.split(':')[1],
-            'status': rhash.split(':')[-1],
-            'children': 'predict:1.tiff:done,predict:2.tiff:failed,predict:3.tiff:new',
-            'children:done': 'predict:4.tiff:done,predict:5.tiff:done',
-            'children:failed': 'predict:6.tiff:failed,predict:7.tiff:failed',
-        }
-
-
-class DummyStorage(object):
-    # pylint: disable=R0201,W0613
-    def __init__(self, num=3):
-        self.num = num
-
-    def download(self, path, dest):
-        if path.lower().endswith('.zip'):
-            paths = []
-            for i in range(self.num):
-                img = _get_image()
-                base, ext = os.path.splitext(path)
-                _path = '{}{}{}'.format(base, i, ext)
-                tiff.imsave(os.path.join(dest, _path), img)
-                paths.append(_path)
-            return utils.zip_files(paths, dest)
-        img = _get_image()
-        tiff.imsave(os.path.join(dest, path), img)
-        return path
-
-    def upload(self, zip_path, subdir=None):
-        return True, True
-
-    def get_public_url(self, zip_path):
-        return True
+from redis_consumer.testing_utils import redis_client, DummyStorage
 
 
 class TestMibiConsumer(object):
     # pylint: disable=R0201
-    def test_is_valid_hash(self):
-        items = ['item%s' % x for x in range(1, 4)]
 
+    def test_is_valid_hash(self, mocker, redis_client):
         storage = DummyStorage()
-        redis_client = DummyRedis(items)
-        redis_client.hget = lambda *x: x[0]
+        mocker.patch.object(redis_client, 'hget', lambda *x: x[0])
 
         consumer = consumers.MibiConsumer(redis_client, storage, 'mibi')
         assert consumer.is_valid_hash(None) is False
@@ -184,30 +56,8 @@ class TestMibiConsumer(object):
         assert consumer.is_valid_hash('mibi:1234567890:file.tiff') is True
         assert consumer.is_valid_hash('mibi:1234567890:file.png') is True
 
-    def test__consume(self):
+    def test__consume(self, mocker, redis_client):
         # pylint: disable=W0613
-        prefix = 'mibi'
-        status = 'new'
-        storage = DummyStorage()
-        redis_client = DummyRedis(prefix, status)
-
-        consumer = consumers.MibiConsumer(redis_client, storage, prefix)
-
-        def _handle_error(err, rhash):
-            raise err
-
-        def grpc_image(data, *args, **kwargs):
-            inner = np.zeros((1, 256, 256, 1))
-            outer = np.zeros((1, 256, 256, 1))
-            fgbg = np.zeros((1, 256, 256, 2))
-            feature = np.zeros((1, 256, 256, 3))
-            return [inner, outer, fgbg, feature]
-
-        def grpc_image_multi(data, *args, **kwargs):
-            return np.array(tuple(list(data.shape) + [2]))
-
-        def grpc_image_list(data, *args, **kwargs):  # pylint: disable=W0613
-            return [data, data]
 
         def make_model_metadata_of_size(model_shape=(-1, 256, 256, 2)):
 
@@ -217,40 +67,63 @@ class TestMibiConsumer(object):
                     'in_tensor_dtype': 'DT_FLOAT',
                     'in_tensor_shape': ','.join(str(s) for s in model_shape),
                 }]
-
             return get_model_metadata
 
-        dummyhash = '{}:new.tiff:{}'.format(prefix, status)
+        def make_grpc_image(model_shape=(-1, 256, 256, 2)):
+            # pylint: disable=E1101
+            shape = model_shape[1:-1]
 
-        model_shape = (-1, 256, 256, 2)
+            def grpc(data, *args, **kwargs):
+                inner = np.random.random((1,) + shape + (1,))
+                outer = np.random.random((1,) + shape + (1,))
+                fgbg = np.random.random((1,) + shape + (2,))
+                feature = np.random.random((1,) + shape + (3,))
+                return [inner, outer, fgbg, feature]
+            return grpc
 
-        consumer._handle_error = _handle_error
-        consumer.grpc_image = grpc_image
+        image_shape = (300, 300, 2)
+        model_shapes = [
+            (-1, 600, 600, 2),  # image too small, pad
+            (-1, 300, 300, 2),  # image is exactly the right size
+            (-1, 150, 150, 2),  # image too big, tile
+        ]
 
-        consumer.get_model_metadata = \
-            make_model_metadata_of_size(model_shape)
+        scales = ['.9', '']
 
-        result = consumer._consume(dummyhash)
-        assert result == consumer.final_status
-        # test with a finished hash
-        result = consumer._consume('{}:test.tiff:{}'.format(
-            prefix, consumer.final_status))
-        assert result == consumer.final_status
-
-        # test with model_name and model_version
-        redis_client.hgetall = lambda x: {
-            'model_name': 'model',
-            'model_version': '0',
-            'postprocess_function': '',
-            'preprocess_function': '',
-            'file_name': 'test_image.tiff',
-            'input_file_name': 'test_image.tiff',
-            'output_file_name': 'test_image.tiff'
+        job_data = {
+            'input_file_name': 'file.tiff',
         }
-        redis_client.hmset = lambda x, y: True
-        consumer = consumers.MibiConsumer(redis_client, storage, prefix)
-        consumer._handle_error = _handle_error
-        consumer.get_model_metadata = make_model_metadata_of_size((-1, 256, 256, 2))
-        consumer.grpc_image = grpc_image
-        result = consumer._consume(dummyhash)
-        assert result == consumer.final_status
+
+        consumer = consumers.MibiConsumer(redis_client, DummyStorage(), 'mibi')
+
+        test_hash = 0
+        # test finished statuses are returned
+        for status in (consumer.failed_status, consumer.final_status):
+            test_hash += 1
+            data = job_data.copy()
+            data['status'] = status
+            redis_client.hmset(test_hash, data)
+            result = consumer._consume(test_hash)
+            assert result == status
+            result = redis_client.hget(test_hash, 'status')
+            assert result == status
+            test_hash += 1
+
+        mocker.patch('redis_consumer.utils.get_image',
+                     lambda x: np.random.random(image_shape))
+
+        for model_shape, scale in itertools.product(model_shapes, scales):
+            metadata = make_model_metadata_of_size(model_shape)
+            grpc_image = make_grpc_image(model_shape)
+            mocker.patch.object(consumer, 'get_model_metadata', metadata)
+            mocker.patch.object(consumer, 'grpc_image', grpc_image)
+
+            data = job_data.copy()
+            data['scale'] = scale
+
+            redis_client.hmset(test_hash, data)
+            result = consumer._consume(test_hash)
+            assert result == consumer.final_status
+            result = redis_client.hget(test_hash, 'status')
+            assert result == consumer.final_status
+            test_hash += 1

--- a/redis_consumer/consumers/mibi_consumer_test.py
+++ b/redis_consumer/consumers/mibi_consumer_test.py
@@ -29,10 +29,8 @@ from __future__ import division
 from __future__ import print_function
 
 import itertools
-import os
 
 import numpy as np
-from skimage.external import tifffile as tiff
 
 import pytest
 

--- a/redis_consumer/consumers/tracking_consumer.py
+++ b/redis_consumer/consumers/tracking_consumer.py
@@ -232,10 +232,8 @@ class TrackingConsumer(TensorFlowServingConsumer):
                 if status == self.final_status:
                     # Segmentation is finished, save and load the frame.
                     with utils.get_tempdir() as tempdir:
-                        frame_zip = self.storage.download(
-                            self.redis.hget(segment_hash, 'output_file_name'),
-                            tempdir)
-
+                        out = self.redis.hget(segment_hash, 'output_file_name')
+                        frame_zip = self.storage.download(out, tempdir)
                         frame_files = list(utils.iter_image_archive(
                             frame_zip, tempdir))
 

--- a/redis_consumer/consumers/tracking_consumer_test.py
+++ b/redis_consumer/consumers/tracking_consumer_test.py
@@ -29,147 +29,25 @@ from __future__ import division
 from __future__ import print_function
 
 import os
-import copy
+import random
+import string
 
 import pytest
 
 import numpy as np
-from skimage.external import tifffile as tiff
+from skimage.external import tifffile
 
+import redis_consumer
 from redis_consumer import consumers
 from redis_consumer import settings
-from redis_consumer import utils
-
-
-def _get_image(img_h=300, img_w=300):
-    bias = np.random.rand(img_w, img_h) * 64
-    variance = np.random.rand(img_w, img_h) * (255 - 64)
-    img = np.random.rand(img_w, img_h) * variance + bias
-    return img
-
-
-class Bunch(object):
-    def __init__(self, **kwds):
-        self.__dict__.update(kwds)
-
-
-class DummyRedis(object):
-    # pylint: disable=R0201,W0613
-    def __init__(self, items=None, prefix='predict', status='new'):
-        items = [] if items is None else items
-        self.work_queue = copy.copy(items)
-        self.processing_queue = []
-        self.prefix = '/'.join(x for x in prefix.split('/') if x)
-        self.status = status
-        self._redis_master = self
-        self.keys = [
-            '{}:{}:{}'.format(self.prefix, 'x.tiff', self.status),
-            '{}:{}:{}'.format(self.prefix, 'x.zip', 'other'),
-            '{}:{}:{}'.format('other', 'x.TIFF', self.status),
-            '{}:{}:{}'.format(self.prefix, 'x.ZIP', self.status),
-            '{}:{}:{}'.format(self.prefix, 'x.tiff', 'other'),
-            '{}:{}:{}'.format('other', 'x.zip', self.status),
-        ]
-
-    def rpoplpush(self, src, dst):
-        if src.startswith('processing'):
-            source = self.processing_queue
-            dest = self.work_queue
-        elif src.startswith(self.prefix):
-            source = self.work_queue
-            dest = self.processing_queue
-
-        try:
-            x = source.pop()
-            dest.insert(0, x)
-            return x
-        except IndexError:
-            return None
-
-    def lpush(self, name, *values):
-        self.work_queue = list(reversed(values)) + self.work_queue
-        return len(self.work_queue)
-
-    def lrem(self, name, count, value):
-        self.processing_queue.remove(value)
-        return count
-
-    def llen(self, queue):
-        if queue.startswith('processing'):
-            return len(self.processing_queue)
-        return len(self.work_queue)
-
-    def hmget(self, rhash, *args):
-        return [self.hget(rhash, a) for a in args]
-
-    def hmset(self, rhash, hvals):  # pylint: disable=W0613
-        return hvals
-
-    def expire(self, name, time):  # pylint: disable=W0613
-        return 1
-
-    def hget(self, rhash, field):
-        if field == 'status':
-            return rhash.split(':')[-1]
-        elif field == 'file_name':
-            return rhash.split(':')[1]
-        elif field == 'input_file_name':
-            return rhash.split(':')[1]
-        elif field == 'output_file_name':
-            return rhash.split(':')[1]
-        elif field == 'reason':
-            return 'reason'
-        return False
-
-    def hset(self, rhash, status, value):  # pylint: disable=W0613
-        return {status: value}
-
-    def hgetall(self, rhash):  # pylint: disable=W0613
-        return {
-            'model_name': 'model',
-            'model_version': '0',
-            'field': '61',
-            'cuts': '0',
-            'postprocess_function': '',
-            'preprocess_function': '',
-            'file_name': rhash.split(':')[1],
-            'input_file_name': rhash.split(':')[1],
-            'output_file_name': rhash.split(':')[1],
-            'status': rhash.split(':')[-1],
-            'children': 'predict:1.tiff:done,predict:2.tiff:failed,predict:3.tiff:new',
-            'children:done': 'predict:4.tiff:done,predict:5.tiff:done',
-            'children:failed': 'predict:6.tiff:failed,predict:7.tiff:failed',
-        }
-
-
-class DummyStorage(object):
-    # pylint: disable=R0201,W0613
-    def __init__(self, num=3):
-        self.num = num
-
-    def download(self, path, dest):
-        if path.lower().endswith('.zip'):
-            paths = []
-            for i in range(self.num):
-                img = _get_image()
-                base, ext = os.path.splitext(path)
-                _path = '{}{}{}'.format(base, i, ext)
-                tiff.imsave(os.path.join(dest, _path), img)
-                paths.append(_path)
-            return utils.zip_files(paths, dest)
-        img = _get_image()
-        tiff.imsave(os.path.join(dest, path), img)
-        return path
-
-    def upload(self, zip_path, subdir=None):
-        return True, True
-
-    def get_public_url(self, zip_path):
-        return True
+from redis_consumer.testing_utils import DummyStorage, redis_client, _get_image
 
 
 class DummyTracker(object):
     # pylint: disable=R0201,W0613
+    def __init__(self, *_, **__):
+        pass
+
     def _track_cells(self):
         return None
 
@@ -187,16 +65,14 @@ class DummyTracker(object):
 
 
 class TestTrackingConsumer(object):
-    # pylint: disable=R0201
-    def test_is_valid_hash(self):
+    # pylint: disable=R0201,W0621
+    def test_is_valid_hash(self, mocker, redis_client):
         queue = 'track'
-        items = ['item%s' % x for x in range(1, 4)]
-
         storage = DummyStorage()
-        redis_client = DummyRedis(items)
-        redis_client.hget = lambda *x: x[0]
-
         consumer = consumers.TrackingConsumer(redis_client, storage, queue)
+
+        mocker.patch.object(redis_client, 'hget', lambda x, y: x.split(':')[-1])
+
         assert consumer.is_valid_hash(None) is False
         assert consumer.is_valid_hash('predict:123456789:file.png') is False
         assert consumer.is_valid_hash('predict:1234567890:file.tiff') is True
@@ -208,61 +84,128 @@ class TestTrackingConsumer(object):
         assert consumer.is_valid_hash('track:1234567890:file.trk') is True
         assert consumer.is_valid_hash('track:1234567890:file.trks') is True
 
-    def test__load_data(self, tmpdir):
+    def test__update_progress(self, redis_client):
         queue = 'track'
-        items = ['item%s' % x for x in range(1, 4)]
-        redis_hash = 'track:1234567890:file.trks'
         storage = DummyStorage()
-        redis_client = DummyRedis(items)
         consumer = consumers.TrackingConsumer(redis_client, storage, queue)
 
-        # test bad filetype
-        with pytest.raises(ValueError):
-            consumer._load_data(redis_hash, str(tmpdir), 'data.npz')
+        redis_hash = 'a job hash'
+        progress = random.randint(0, 99)
+        consumer._update_progress(redis_hash, progress)
+        assert int(redis_client.hget(redis_hash, 'progress')) == progress
 
-        # TODO: test successful workflow
-
-    def test__get_tracker(self):
+    def test__load_data(self, tmpdir, mocker, redis_client):
         queue = 'track'
-        items = ['item%s' % x for x in range(1, 4)]
-
         storage = DummyStorage()
-        redis_client = DummyRedis(items)
-        redis_client.hget = lambda *x: x[0]
+        consumer = consumers.TrackingConsumer(redis_client, storage, queue)
+        tmpdir = str(tmpdir)
+        exp = random.randint(0, 99)
+
+        # test load trk files
+        key = 'trk file test'
+        mocker.patch('redis_consumer.utils.load_track_file', lambda x: exp)
+        result = consumer._load_data(key, tmpdir, 'data.trk')
+        assert result == exp
+        result = consumer._load_data(key, tmpdir, 'data.trks')
+        assert result == exp
+
+        # test bad filetype
+        key = 'invalid filetype test'
+        with pytest.raises(ValueError):
+            consumer._load_data(key, tmpdir, 'data.npz')
+
+        # test bad ndim for tiffstack
+        fname = 'test.tiff'
+        filepath = os.path.join(tmpdir, fname)
+        tifffile.imsave(filepath, _get_image())
+        with pytest.raises(ValueError):
+            consumer._load_data(key, tmpdir, fname)
+
+        # test successful workflow
+        def hget_successful_status(*_):
+            return consumer.final_status
+
+        def hget_failed_status(*_):
+            return consumer.failed_status
+
+        def write_child_tiff(*_, **__):
+            letters = string.ascii_lowercase
+            name = ''.join(random.choice(letters) for i in range(12))
+            path = os.path.join(tmpdir, '{}.tiff'.format(name))
+            tifffile.imsave(path, _get_image(21, 21))
+            return [path]
+
+        mocker.patch.object(settings, 'INTERVAL', 0)
+        mocker.patch.object(redis_client, 'hget', hget_successful_status)
+        mocker.patch('redis_consumer.utils.iter_image_archive',
+                     write_child_tiff)
+
+        for label_detect in (True, False):
+            mocker.patch.object(settings, 'SCALE_DETECT_ENABLED', label_detect)
+            mocker.patch.object(settings, 'LABEL_DETECT_ENABLED', label_detect)
+
+            tifffile.imsave(filepath, np.random.random((3, 21, 21)))
+            results = consumer._load_data(key, tmpdir, fname)
+            X, y = results.get('X'), results.get('y')
+            assert isinstance(X, np.ndarray)
+            assert isinstance(y, np.ndarray)
+            assert X.shape == y.shape
+
+        # test failed child
+        with pytest.raises(RuntimeError):
+            mocker.patch.object(redis_client, 'hget', hget_failed_status)
+            consumer._load_data(key, tmpdir, fname)
+
+        # test wrong number of images in the test file
+        with pytest.raises(RuntimeError):
+            mocker.patch.object(redis_client, 'hget', hget_successful_status)
+            mocker.patch('redis_consumer.utils.iter_image_archive',
+                         lambda *x: range(1, 3))
+            consumer._load_data(key, tmpdir, fname)
+
+    def test__get_tracker(self, mocker, redis_client):
+        queue = 'track'
+        storage = DummyStorage()
 
         shape = (5, 21, 21, 1)
         raw = np.random.random(shape)
         segmented = np.random.randint(1, 10, size=shape)
 
-        settings.NORMALIZE_TRACKING = True
-
+        mocker.patch.object(settings, 'NORMALIZE_TRACKING', True)
         consumer = consumers.TrackingConsumer(redis_client, storage, queue)
-        consumer._get_tracker('item1', {}, raw, segmented)
+        tracker = consumer._get_tracker('item1', {}, raw, segmented)
+        assert isinstance(tracker, redis_consumer.tracking.CellTracker)
 
-    def test__consume(self):
+    def test__consume(self, mocker, redis_client):
         queue = 'track'
-        items = ['item%s' % x for x in range(1, 4)]
-
         storage = DummyStorage()
-        redis_client = DummyRedis(items)
-        redis_client.hget = lambda *x: x[0]
+        test_hash = 0
 
-        # test short-circuit _consume()
         consumer = consumers.TrackingConsumer(redis_client, storage, queue)
 
-        status = 'done'
-        dummyhash = '{queue}:{fname}.zip:{status}'.format(
-            queue=queue, status=status, fname=status)
+        mocker.patch.object(consumer, '_get_tracker', DummyTracker)
+        mocker.patch.object(settings, 'DRIFT_CORRECT_ENABLED', True)
 
-        result = consumer._consume(dummyhash)
-        assert result == status
+        frames = 3
+        dummy_data = {
+            'X': np.array([_get_image(21, 21) for _ in range(frames)]),
+            'y': np.random.randint(0, 9, size=(frames, 21, 21)),
+        }
 
-        # test valid _consume flow
-        status = 'new'
-        dummyhash = '{queue}:{fname}.zip:{status}'.format(
-            queue=queue, status=status, fname=status)
-        dummy_data = np.zeros((1, 1, 1))
-        consumer._load_data = lambda *x: {'X': dummy_data, 'y': dummy_data}
-        consumer._get_tracker = lambda *args: DummyTracker()
-        result = consumer._consume(dummyhash)
+        mocker.patch.object(consumer, '_load_data', lambda *x: dummy_data)
+
+        # test finished statuses are returned
+        for status in (consumer.failed_status, consumer.final_status):
+            test_hash += 1
+            data = {'input_file_name': 'file.tiff', 'status': status}
+            redis_client.hmset(test_hash, data)
+            result = consumer._consume(test_hash)
+            assert result == status
+
+        # test new key is processed
+        test_hash += 1
+        data = {'input_file_name': 'file.tiff', 'status': 'new'}
+        redis_client.hmset(test_hash, data)
+        result = consumer._consume(test_hash)
         assert result == consumer.final_status
+        assert redis_client.hget(test_hash, 'status') == consumer.final_status

--- a/redis_consumer/consumers/tracking_consumer_test.py
+++ b/redis_consumer/consumers/tracking_consumer_test.py
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.github.com/vanvalenlab/kiosk-data-processing/LICENSE
+#     http://www.github.com/vanvalenlab/kiosk-redis-consumer/LICENSE
 #
 # The Work provided may be used for non-commercial academic purposes only.
 # For any other use of the Work, including commercial use, please contact:

--- a/redis_consumer/redis_test.py
+++ b/redis_consumer/redis_test.py
@@ -23,96 +23,121 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ============================================================================
-"""Tests for Redis client wrapper class"""
+"""Tests for RedisClient wrapper class"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
 import random
+import time
 
+import fakeredis
 import redis
 import pytest
 
-import redis_consumer
+from redis_consumer.redis import RedisClient
 
 
-FAIL_COUNT = 0
+class WrappedFakeStrictRedis(fakeredis.FakeStrictRedis):
+    """Wrapper around fakeredis instance to mock errors and sentinel mode."""
 
+    def __init__(self, *_, **kwargs):
+        super(WrappedFakeStrictRedis, self).__init__(decode_responses='utf8')
+        self.should_fail = kwargs.get('should_fail', False)
 
-class DummyRedis(object):
-    def __init__(self, fail_tolerance=0, hard_fail=False, err=None):
-        self.fail_tolerance = fail_tolerance
-        self.hard_fail = hard_fail
-        if err is None:
-            err = redis.exceptions.ConnectionError('thrown on purpose')
-        self.err = err
-
-    def get_fail_count(self):
-        global FAIL_COUNT
-        if self.hard_fail:
-            raise AssertionError('thrown on purpose')
-        if FAIL_COUNT < self.fail_tolerance:
-            FAIL_COUNT += 1
-            raise self.err
-        return FAIL_COUNT
-
-    def sentinel_masters(self):
+    def sentinel_masters(self, *_, **__):
         return {'mymaster': {'ip': 'master', 'port': 6379}}
 
-    def sentinel_slaves(self, _):
-        n = random.randint(1, 4)
+    def sentinel_slaves(self, *_, **__):
+        n = random.randint(2, 5)
         return [{'ip': 'slave', 'port': 6379} for i in range(n)]
+
+    def busy_error(self, *_, **__):
+        if self.should_fail:
+            self.should_fail = False
+            raise redis.exceptions.ResponseError('BUSY SCRIPT KILL ERROR')
+        return True
+
+    def connect_error(self, *_, **__):
+        if self.should_fail:
+            self.should_fail = False
+            raise redis.exceptions.ConnectionError('thrown on purpose')
+        return True
+
+    def fail(self, *_, **__):
+        raise redis.exceptions.ResponseError('thrown on purpose')
 
 
 class TestRedis(object):
+    # pylint: disable=R0201
 
-    def test_redis_client(self):  # pylint: disable=R0201
-        global FAIL_COUNT
-
-        fails = random.randint(1, 3)
-        RedisClient = redis_consumer.redis.RedisClient
-
-        # monkey patch _get_redis_client function to use DummyRedis client
-        def _get_redis_client(*args, **kwargs):  # pylint: disable=W0613
-            return DummyRedis(fail_tolerance=fails)
-
-        RedisClient._get_redis_client = _get_redis_client
+    def test_successful_command(self, mocker):
+        mocker.patch('redis.StrictRedis', WrappedFakeStrictRedis)
+        mocker.patch('redis_consumer.redis.RedisClient.'
+                     '_update_masters_and_slaves')
 
         client = RedisClient(host='host', port='port', backoff=0)
-        assert client.get_fail_count() == fails
-        FAIL_COUNT = 0  # reset for the next test
 
+        # send some test requests using fakeredis
+        key = 'job_id'
+        values = {'data': str(random.randint(0, 100))}
+
+        client.hmset(key, values)  # Non-readonly
+        new_values = client.hgetall(key)
+
+        assert new_values == values
+
+        # test attribute error is thrown if invalid command.
         with pytest.raises(AttributeError):
             client.unknown_function()
 
-        # test ResponseError BUSY - should retry
-        def _get_redis_client_retry(*args, **kwargs):  # pylint: disable=W0613
-            err = redis.exceptions.ResponseError('BUSY SCRIPT KILL')
-            return DummyRedis(fail_tolerance=fails, err=err)
-
-        RedisClient._get_redis_client = _get_redis_client_retry
-
-        client = RedisClient(host='host', port='port', backoff=0)
-        assert client.get_fail_count() == fails
-        FAIL_COUNT = 0  # reset for the next test
-
-        # test ResponseError other - should fail
-        def _get_redis_client_err(*args, **kwargs):  # pylint: disable=W0613
-            err = redis.exceptions.ResponseError('OTHER ERROR')
-            return DummyRedis(fail_tolerance=fails, err=err)
-
-        RedisClient._get_redis_client = _get_redis_client_err
+    def test__update_masters_and_slaves(self, mocker):
+        mocker.patch('redis.StrictRedis', WrappedFakeStrictRedis)
         client = RedisClient(host='host', port='port', backoff=0)
 
+        master = client._redis_master
+        slaves = client._redis_slaves
+
+        # new master is same class but different instance.
+        assert isinstance(master, WrappedFakeStrictRedis)
+        assert isinstance(master, type(client._sentinel))
+        assert master is not client._sentinel
+
+        # starts with 1 slave, but should be 2 - 4 from mocked update.
+        assert len(slaves) > 1
+        for slave in slaves:
+            assert isinstance(slave, WrappedFakeStrictRedis)
+            assert isinstance(slave, type(client._sentinel))
+            assert slave is not client._sentinel
+
+        # test response error does not raise
+        def redis_response_error(*_, **__):
+            raise redis.exceptions.ResponseError('thrown on purpose')
+
+        mocker.patch('redis_consumer.redis.RedisClient._get_redis_client',
+                     redis_response_error)
+        client._update_masters_and_slaves()
+
+    def test_error_handling(self, mocker):
+        mocker.patch('redis.StrictRedis',
+                     lambda *_, **__: WrappedFakeStrictRedis(should_fail=True))
+        mocker.patch('redis_consumer.redis.RedisClient.'
+                     '_update_masters_and_slaves')
+
+        client = RedisClient(host='host', port='port', backoff=0)
         with pytest.raises(redis.exceptions.ResponseError):
-            client.get_fail_count()
+            client.fail()
 
-        # test that other exceptions will raise.
-        def _get_redis_client_bad(*args, **kwargs):  # pylint: disable=W0613
-            return DummyRedis(fail_tolerance=fails, hard_fail=True)
-
-        RedisClient._get_redis_client = _get_redis_client_bad
-
+        # mocked up ConnectionError
         client = RedisClient(host='host', port='port', backoff=0)
-        with pytest.raises(AssertionError):
-            client.get_fail_count()
+        spy = mocker.spy(client, '_update_masters_and_slaves')
+        response = client.connect_error()
+        assert response
+        spy.assert_called_once_with()
+
+        # mocked up retry-able ResponseError
+        client = RedisClient(host='host', port='port', backoff=0)
+        spy = mocker.spy(time, 'sleep')
+        response = client.busy_error()
+        assert response
+        spy.assert_called_once_with(client.backoff)

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -119,6 +119,7 @@ METADATA_EXPIRE_TIME = config('METADATA_EXPIRE_TIME', default=30, cast=int)
 PROCESSING_FUNCTIONS = {
     'pre': {
         'normalize': processing.normalize,
+        'histogram_normalization': processing.phase_preprocess,
     },
     'post': {
         'deepcell': processing.pixelwise,  # TODO: this is deprecated.
@@ -127,6 +128,7 @@ PROCESSING_FUNCTIONS = {
         'retinanet': processing.retinanet_to_label_image,
         'retinanet-semantic': processing.retinanet_semantic_to_label_image,
         'deep_watershed': processing.deep_watershed,
+        'mibi': processing.deep_watershed_mibi,
     },
 }
 

--- a/redis_consumer/storage.py
+++ b/redis_consumer/storage.py
@@ -38,9 +38,9 @@ import socket
 import urllib3
 
 import boto3
-from google.cloud import storage as google_storage
-from google.cloud import exceptions as google_exceptions
-from google.auth import exceptions as auth_exceptions
+import google.auth.exceptions
+import google.cloud.exceptions
+import google.cloud.storage
 import requests
 
 from redis_consumer import settings
@@ -157,16 +157,16 @@ class GoogleStorage(Storage):
         self.bucket_url = 'www.googleapis.com/storage/v1/b/{}/o'.format(bucket)
         self._network_errors = (
             socket.gaierror,
-            google_exceptions.TooManyRequests,
-            google_exceptions.InternalServerError,
-            google_exceptions.ServiceUnavailable,
-            google_exceptions.GatewayTimeout,
+            google.cloud.exceptions.TooManyRequests,
+            google.cloud.exceptions.InternalServerError,
+            google.cloud.exceptions.ServiceUnavailable,
+            google.cloud.exceptions.GatewayTimeout,
             urllib3.exceptions.MaxRetryError,
             urllib3.exceptions.NewConnectionError,
             requests.exceptions.ConnectionError,
             requests.exceptions.ReadTimeout,
-            auth_exceptions.RefreshError,
-            auth_exceptions.TransportError,
+            google.auth.exceptions.RefreshError,
+            google.auth.exceptions.TransportError,
         )
 
     def get_storage_client(self):
@@ -174,7 +174,7 @@ class GoogleStorage(Storage):
         attempts = 0
         while True:
             try:
-                return google_storage.Client()
+                return google.cloud.storage.Client()
             except OSError as err:
                 if attempts < 3:
                     backoff = self.get_backoff(attempts)

--- a/redis_consumer/testing_utils.py
+++ b/redis_consumer/testing_utils.py
@@ -1,0 +1,86 @@
+# Copyright 2016-2020 The Van Valen Lab at the California Institute of
+# Technology (Caltech), with support from the Paul Allen Family Foundation,
+# Google, & National Institutes of Health (NIH) under Grant U24CA224309-01.
+# All rights reserved.
+#
+# Licensed under a modified Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.github.com/vanvalenlab/kiosk-redis-consumer/LICENSE
+#
+# The Work provided may be used for non-commercial academic purposes only.
+# For any other use of the Work, including commercial use, please contact:
+# vanvalenlab@gmail.com
+#
+# Neither the name of Caltech nor the names of its contributors may be used
+# to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Common tests and fixtures for unit tests"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+
+import numpy as np
+from skimage.external import tifffile as tiff
+
+import pytest
+import fakeredis
+
+from redis_consumer import utils
+
+
+@pytest.fixture
+def redis_client():
+    client = fakeredis.FakeStrictRedis(decode_responses='utf8')
+    # patch the _redis_master field
+    client._redis_master = client
+    client._update_masters_and_slaves = lambda: True
+    yield client
+
+
+def _get_image(img_h=300, img_w=300):
+    bias = np.random.rand(img_w, img_h) * 64
+    variance = np.random.rand(img_w, img_h) * (255 - 64)
+    img = np.random.rand(img_w, img_h) * variance + bias
+    return img
+
+
+class Bunch(object):
+    def __init__(self, **kwds):
+        self.__dict__.update(kwds)
+
+
+class DummyStorage(object):
+    # pylint: disable=W0613,R0201
+    def __init__(self, num=3):
+        self.num = num
+
+    def download(self, path, dest):
+        if path.lower().endswith('.zip'):
+            paths = []
+            for i in range(self.num):
+                img = _get_image()
+                base, ext = os.path.splitext(path)
+                _path = '{}{}{}'.format(base, i, ext)
+                tiff.imsave(os.path.join(dest, _path), img)
+                paths.append(_path)
+            return utils.zip_files(paths, dest)
+        img = _get_image()
+        tiff.imsave(os.path.join(dest, path), img)
+        return path
+
+    def upload(self, zip_path, subdir=None):
+        return 'zip_path.zip', 'blob.public_url'
+
+    def get_public_url(self, zip_path):
+        return 'blob.public_url'

--- a/redis_consumer/tracking.py
+++ b/redis_consumer/tracking.py
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.github.com/vanvalenlab/deepcell-tf/LICENSE
+#     http://www.github.com/vanvalenlab/kiosk-redis-consumer/LICENSE
 #
 # The Work provided may be used for non-commercial academic purposes only.
 # For any other use of the Work, including commercial use, please contact:

--- a/redis_consumer/tracking_test.py
+++ b/redis_consumer/tracking_test.py
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.github.com/vanvalenlab/deepcell-tracking/LICENSE
+#     http://www.github.com/vanvalenlab/kiosk-redis-consumer/LICENSE
 #
 # The Work provided may be used for non-commercial academic purposes only.
 # For any other use of the Work, including commercial use, please contact:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,7 @@
+pytest
+pytest-cov==2.5.1
+pytest-mock
+pytest-pep8
+fakeredis
+six>=1.12
+coveralls


### PR DESCRIPTION
This PR updates the MIBI branch with the new testing changes in master, and updates the mibi tests to better use the new testing_utils.py.

It also updates the MibiConsumer to inherit from the ImageFileConsumer so that we can make better use of the already built-in preprocess and postprocess functions. Just needed to add some keys to the `settings.PROCESSING_FUNCTIONS` object to make it all connect.

I just have a concern about the `get_image` call, as .tiff files automatically add a single-dimension channel...but these images already have a channel-dim of 2 I think.