### PR TITLE
Update deepcell-toolbox and deepcell-tracking to latest patches.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ dict-to-protobuf==0.0.3.9
 pytz==2019.1
 deepcell-tracking==0.2.5
 deepcell-toolbox==0.6.1
+opencv-python>=3.4.2.17,<4

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,5 @@ keras-preprocessing==1.1.0
 grpcio==1.27.2
 dict-to-protobuf==0.0.3.9
 pytz==2019.1
-deepcell-tracking==0.2.5
-deepcell-toolbox==0.6.1
-opencv-python>=3.4.2.17,<4
+deepcell-tracking==0.2.6
+deepcell-toolbox==0.6.2


### PR DESCRIPTION
The new patches resolve a versioning compatibility issue with newer versions of OpenCV.