### PR TITLE
Set a maximum image height/width.

### DIFF
--- a/redis_consumer/consumers/base_consumer.py
+++ b/redis_consumer/consumers/base_consumer.py
@@ -553,6 +553,15 @@ class TensorFlowServingConsumer(Consumer):
                                  image.shape, model_name, model_version,
                                  tuple(model_shape)))
 
+        if (image.shape[-2] > settings.MAX_IMAGE_WIDTH or
+                image.shape[-3] > settings.MAX_IMAGE_HEIGHT):
+            raise ValueError(
+                'The image is too large! Rescaled images have a maximum size '
+                'of ({}, {}) but found size {}.'.format(
+                    settings.MAX_IMAGE_WIDTH,
+                    settings.MAX_IMAGE_HEIGHT,
+                    image.shape))
+
         size_x = model_shape[model_ndim - 3]
         size_y = model_shape[model_ndim - 2]
 

--- a/redis_consumer/consumers/base_consumer_test.py
+++ b/redis_consumer/consumers/base_consumer_test.py
@@ -362,6 +362,13 @@ class TestTensorFlowServingConsumer(object):
             consumer.predict(x, model_name='modelname', model_version=0,
                              untile=untile)
 
+        # test image larger than max dimensions
+        with pytest.raises(ValueError):
+            mocker.patch.object(settings, 'MAX_IMAGE_WIDTH', 300)
+            mocker.patch.object(settings, 'MAX_IMAGE_HEIGHT', 300)
+            x = np.random.random((301, 301, 1))
+            consumer.predict(x, model_name='modelname', model_version=0)
+
         # test mismatch of input data and model shape
         with pytest.raises(ValueError):
             x = np.random.random((5,))

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -48,6 +48,8 @@ DEBUG = config('DEBUG', cast=bool, default=False)
 INTERVAL = config('INTERVAL', default=10, cast=int)
 CONSUMER_TYPE = config('CONSUMER_TYPE', default='image')
 MAX_RETRY = config('MAX_RETRY', default=5, cast=int)
+MAX_IMAGE_HEIGHT = config('MAX_IMAGE_HEIGHT', default=2048, cast=int)
+MAX_IMAGE_WIDTH = config('MAX_IMAGE_WIDTH', default=2048, cast=int)
 
 # Redis client connection
 REDIS_HOST = config('REDIS_HOST', default='redis-master')


### PR DESCRIPTION
set default `MAX_IMAGE_HEIGHT` and `MAX_IMAGE_WIDTH` and raise an error if `predict()` finds a larger image.

Closes #127 