### PR TITLE
Fix test dependencies for Python 3.5 versioning issue.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache: pip
 
 install:
   - travis_retry pip install -r requirements.txt
-  - travis_retry pip install -r requirements-test.txt
+  - travis_retry pip install --upgrade -r requirements-test.txt
   # install documentation requirements
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.7" ]]; then
       travis_retry pip install -r docs/rtd-requirements.txt;

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 pytest
-pytest-cov==2.5.1
+pytest-cov
 pytest-mock
 pytest-pep8
 fakeredis


### PR DESCRIPTION
Travis uses `pytest==4.X` for the Python 3.5 environment, which causes issues with a new release of `pytest-mock`. Instead of pinning `pytest>=5.X`, which does not support Python 2.7, we can `--upgrade` the requirements-test.txt file to update already installed dependencies.