### PR TITLE
Updated multiplex model

### DIFF
--- a/redis_consumer/consumers/multiplex_consumer.py
+++ b/redis_consumer/consumers/multiplex_consumer.py
@@ -119,7 +119,7 @@ class MultiplexConsumer(ImageFileConsumer):
         image = np.expand_dims(image, axis=0)  # add in the batch dim
 
         # Preprocess image
-        image = self.preprocess(image, ['histogram_normalization'])
+        image = self.preprocess(image, ['multiplex_preprocess'])
 
         # Send data to the model
         self.update_key(redis_hash, {'status': 'predicting'})
@@ -128,7 +128,7 @@ class MultiplexConsumer(ImageFileConsumer):
         # Post-process model results
         self.update_key(redis_hash, {'status': 'post-processing'})
         image = processing.format_output_multiplex(image)
-        image = self.postprocess(image, ['deep_watershed_subcellular'])
+        image = self.postprocess(image, ['multiplex_postprocess'])
 
         # Save the post-processed results to a file
         _ = timeit.default_timer()

--- a/redis_consumer/consumers/multiplex_consumer_test.py
+++ b/redis_consumer/consumers/multiplex_consumer_test.py
@@ -73,15 +73,11 @@ class TestMultiplexConsumer(object):
 
             def grpc(data, *args, **kwargs):
                 inner = np.random.random((1,) + shape + (1,))
-                outer = np.random.random((1,) + shape + (1,))
-                fgbg = np.random.random((1,) + shape + (2,))
                 feature = np.random.random((1,) + shape + (3,))
 
                 inner2 = np.random.random((1,) + shape + (1,))
-                outer2 = np.random.random((1,) + shape + (1,))
-                fgbg2 = np.random.random((1,) + shape + (2,))
                 feature2 = np.random.random((1,) + shape + (3,))
-                return [inner, outer, fgbg, feature, inner2, outer2, fgbg2, feature2]
+                return [inner, feature, inner2, feature2]
             return grpc
 
         image_shapes = [

--- a/redis_consumer/processing.py
+++ b/redis_consumer/processing.py
@@ -42,9 +42,8 @@ from deepcell_toolbox import correct_drift
 from deepcell_toolbox.deep_watershed import deep_watershed
 
 # import mibi pre- and post-processing functions
-from deepcell_toolbox.deep_watershed import deep_watershed_mibi
-from deepcell.applications.multiplex_segmentation import multiplex_preprocess
-from deepcell.applications.multiplex_segmentation import  multiplex_postprocess
+from deepcell_toolbox.multiplex_utils import \
+    multiplex_preprocess, multiplex_postprocess, format_output_multiplex
 
 from deepcell_toolbox import retinanet_semantic_to_label_image
 from deepcell_toolbox import retinanet_to_label_image

--- a/redis_consumer/processing.py
+++ b/redis_consumer/processing.py
@@ -43,9 +43,8 @@ from deepcell_toolbox.deep_watershed import deep_watershed
 
 # import mibi pre- and post-processing functions
 from deepcell_toolbox.deep_watershed import deep_watershed_mibi
-from deepcell_toolbox.deep_watershed import format_output_multiplex
-from deepcell_toolbox.deep_watershed import deep_watershed_subcellular
-from deepcell_toolbox.processing import phase_preprocess
+from deepcell.applications.multiplex_segmentation import multiplex_preprocess
+from deepcell.applications.multiplex_segmentation import  multiplex_postprocess
 
 from deepcell_toolbox import retinanet_semantic_to_label_image
 from deepcell_toolbox import retinanet_to_label_image

--- a/redis_consumer/processing.py
+++ b/redis_consumer/processing.py
@@ -42,6 +42,7 @@ from deepcell_toolbox import correct_drift
 from deepcell_toolbox.deep_watershed import deep_watershed
 
 # import mibi pre- and post-processing functions
+from deepcell_toolbox.processing import phase_preprocess
 from deepcell_toolbox.multiplex_utils import \
     multiplex_preprocess, multiplex_postprocess, format_output_multiplex
 

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -162,7 +162,7 @@ LABEL_DETECT_MODEL = config('LABEL_DETECT_MODEL', default='LabelDetection:1', ca
 LABEL_DETECT_ENABLED = config('LABEL_DETECT_ENABLED', default=False, cast=bool)
 
 # Multiplex model Settings
-MULTIPLEX_MODEL = config('MULTIPLEX_MODEL', default='MultiplexSegmentation:3', cast=str)
+MULTIPLEX_MODEL = config('MULTIPLEX_MODEL', default='MultiplexSegmentation:4', cast=str)
 
 # Set default models based on label type
 MODEL_CHOICES = {

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -122,6 +122,7 @@ PROCESSING_FUNCTIONS = {
     'pre': {
         'normalize': processing.normalize,
         'histogram_normalization': processing.phase_preprocess,
+        'multiplex_preprocess': processing.multiplex_preprocess
     },
     'post': {
         'deepcell': processing.pixelwise,  # TODO: this is deprecated.
@@ -130,8 +131,7 @@ PROCESSING_FUNCTIONS = {
         'retinanet': processing.retinanet_to_label_image,
         'retinanet-semantic': processing.retinanet_semantic_to_label_image,
         'deep_watershed': processing.deep_watershed,
-        'multiplex': processing.deep_watershed_mibi,
-        'deep_watershed_subcellular': processing.deep_watershed_subcellular,
+        'multiplex': processing.multiplex_postprocess,
     },
 }
 

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -121,7 +121,6 @@ METADATA_EXPIRE_TIME = config('METADATA_EXPIRE_TIME', default=30, cast=int)
 PROCESSING_FUNCTIONS = {
     'pre': {
         'normalize': processing.normalize,
-        'histogram_normalization': processing.phase_preprocess,
         'multiplex_preprocess': processing.multiplex_preprocess
     },
     'post': {
@@ -131,7 +130,7 @@ PROCESSING_FUNCTIONS = {
         'retinanet': processing.retinanet_to_label_image,
         'retinanet-semantic': processing.retinanet_semantic_to_label_image,
         'deep_watershed': processing.deep_watershed,
-        'multiplex': processing.multiplex_postprocess,
+        'multiplex_postprocess': processing.multiplex_postprocess,
     },
 }
 

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -121,6 +121,7 @@ METADATA_EXPIRE_TIME = config('METADATA_EXPIRE_TIME', default=30, cast=int)
 PROCESSING_FUNCTIONS = {
     'pre': {
         'normalize': processing.normalize,
+        'histogram_normalization': processing.phase_preprocess,
         'multiplex_preprocess': processing.multiplex_preprocess
     },
     'post': {

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,4 @@ grpcio==1.27.2
 dict-to-protobuf==0.0.3.9
 pytz==2019.1
 deepcell-tracking==0.2.6
-deepcell-toolbox=>0.7
-git+https://github.com/vanvalenlab/deepcell-tf.git@43179b50c224e073c3a30e7da94c61445b19ae6f
+deepcell-toolbox=>0.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ dict-to-protobuf==0.0.3.9
 pytz==2019.1
 deepcell-tracking==0.2.6
 deepcell-toolbox==0.6.2
+git+https://github.com/vanvalenlab/deepcell-tf.git@43179b50c224e073c3a30e7da94c61445b19ae6f

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ grpcio==1.27.2
 dict-to-protobuf==0.0.3.9
 pytz==2019.1
 deepcell-tracking==0.2.6
-deepcell-toolbox==0.6.2
+deepcell-toolbox=>0.7
 git+https://github.com/vanvalenlab/deepcell-tf.git@43179b50c224e073c3a30e7da94c61445b19ae6f

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ grpcio==1.27.2
 dict-to-protobuf==0.0.3.9
 pytz==2019.1
 deepcell-tracking==0.2.6
-deepcell-toolbox=>0.8.0
+deepcell-toolbox>=0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ grpcio==1.27.2
 dict-to-protobuf==0.0.3.9
 pytz==2019.1
 deepcell-tracking==0.2.6
-deepcell-toolbox=>0.7.1
+deepcell-toolbox=>0.8.0


### PR DESCRIPTION
Updates the multiplex model to the newest version

- Bump model version from 3 to 4 in GCS bucket
- Modify test functions for 2-head rather than 4-head output
- Update post-processing functions to use new versions in deepcell.applications