### PR TITLE
use pytest 5.x for now to resolve issue with pep8 test collections in 6.x

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-pytest
+pytest<6
 pytest-cov
 pytest-mock
 pytest-pep8


### PR DESCRIPTION
Currently getting the following error which is new in PyTest 6.x:

```
Direct construction of Pep8Item has been deprecated, please use Pep8Item.from_parent.

See https://docs.pytest.org/en/stable/deprecations.html#node-construction-changed-to-node-from-parent for more details.
```