### PR TITLE
Add a "none" pre/post-process option to do nothing

### DIFF
--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -122,7 +122,8 @@ PROCESSING_FUNCTIONS = {
     'pre': {
         'normalize': processing.normalize,
         'histogram_normalization': processing.phase_preprocess,
-        'multiplex_preprocess': processing.multiplex_preprocess
+        'multiplex_preprocess': processing.multiplex_preprocess,
+        'none': lambda x: x
     },
     'post': {
         'deepcell': processing.pixelwise,  # TODO: this is deprecated.
@@ -132,6 +133,7 @@ PROCESSING_FUNCTIONS = {
         'retinanet-semantic': processing.retinanet_semantic_to_label_image,
         'deep_watershed': processing.deep_watershed,
         'multiplex_postprocess_consumer': processing.multiplex_postprocess_consumer,
+        'none': lambda x: x
     },
 }
 


### PR DESCRIPTION
Passing an empty string as an environment variable does not work, as the variable is ignored and the default value is used. By using `"none"` as a key, we can specifically tell the consumers to not process the data and to just return the model results directly.