### PR TITLE
Bump toolbox version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ grpcio==1.27.2
 dict-to-protobuf==0.0.3.9
 pytz==2019.1
 deepcell-tracking==0.2.6
-deepcell-toolbox>=0.8.0
+deepcell-toolbox>=0.8.1


### PR DESCRIPTION
The newest toolbox release has a bugfix for images with a blank channel. This bumps the required toolbox version so we can deploy that fix to deepcell.org