### PR TITLE
Return all output signatures from gRPC response.

### DIFF
--- a/redis_consumer/consumers/base_consumer.py
+++ b/redis_consumer/consumers/base_consumer.py
@@ -309,8 +309,7 @@ class TensorFlowServingConsumer(Consumer):
         client = self._get_predict_client(model_name, model_version)
 
         prediction = client.predict(req_data, settings.GRPC_TIMEOUT)
-        results = [prediction[k] for k in sorted(prediction.keys())
-                   if k.startswith('prediction')]
+        results = [prediction[k] for k in sorted(prediction.keys())]
 
         if len(results) == 1:
             results = results[0]


### PR DESCRIPTION
Not all models have "prediction" as a key, the consumers should accept all outputs.

This change decouples the consumers from the model export step.