### PR TITLE
Set a MAX_SCALE and MIN_SCALE, raise ValueError if provided scale is outside.

### DIFF
--- a/redis_consumer/consumers/base_consumer.py
+++ b/redis_consumer/consumers/base_consumer.py
@@ -389,6 +389,29 @@ class TensorFlowServingConsumer(Consumer):
             self.logger.error('Malformed metadata: %s', model_metadata)
             raise err
 
+    def detect_scale(self, image):  # pylint: disable=unused-argument
+        """Stub for scale detection"""
+        self.logger.debug('Scale was not given. Defaults to 1')
+        scale = 1
+        return scale
+
+    def get_image_scale(self, scale, image, redis_hash):
+        """Calculate scale of image and rescale"""
+        if not scale:
+            # Detect scale of image (Default to 1)
+            scale = self.detect_scale(image)
+            self.logger.debug('Image scale detected: %s', scale)
+            self.update_key(redis_hash, {'scale': scale})
+        else:
+            scale = float(scale)
+            self.logger.debug('Image scale already calculated %s', scale)
+            if not settings.MIN_SCALE <= scale <= settings.MAX_SCALE:
+                raise ValueError('Provided scale {} is outside of the valid '
+                                 'scale range: [{}, {}].'.format(
+                                     scale, settings.MIN_SCALE,
+                                     settings.MAX_SCALE))
+        return scale
+
     def _predict_big_image(self,
                            image,
                            model_name,

--- a/redis_consumer/consumers/image_consumer.py
+++ b/redis_consumer/consumers/image_consumer.py
@@ -148,15 +148,7 @@ class ImageFileConsumer(TensorFlowServingConsumer):
 
         # Calculate scale of image and rescale
         scale = hvals.get('scale', '')
-        if not scale:
-            # Detect scale of image
-            scale = self.detect_scale(image)
-            self.logger.debug('Image scale detected: %s', scale)
-            self.update_key(redis_hash, {'scale': scale})
-        else:
-            scale = float(scale)
-            self.logger.debug('Image scale already calculated: %s', scale)
-
+        scale = self.get_image_scale(scale, image, redis_hash)
         image = utils.rescale(image, scale)
 
         # Save shape value for postprocessing purposes

--- a/redis_consumer/consumers/multiplex_consumer.py
+++ b/redis_consumer/consumers/multiplex_consumer.py
@@ -100,19 +100,9 @@ class MultiplexConsumer(ImageFileConsumer):
             'download_time': timeit.default_timer() - _,
         })
 
-        # Calculate scale of image and rescale
+        # TODO: implement detect_scale here for multiplex model
         scale = hvals.get('scale', '')
-        if not scale:
-            # Detect scale of image (Default to 1)
-            # TODO: implement SCALE_DETECT here for multiplex model
-            # scale = self.detect_scale(image)
-            # self.logger.debug('Image scale detected: %s', scale)
-            # self.update_key(redis_hash, {'scale': scale})
-            self.logger.debug('Scale was not given. Defaults to 1')
-            scale = 1
-        else:
-            scale = float(scale)
-            self.logger.debug('Image scale already calculated %s', scale)
+        scale = self.get_image_scale(scale, image, redis_hash)
 
         # Rescale each channel of the image
         image = utils.rescale(image, scale)

--- a/redis_consumer/consumers/multiplex_consumer.py
+++ b/redis_consumer/consumers/multiplex_consumer.py
@@ -28,19 +28,25 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import os
 import timeit
 
 import numpy as np
 
-from redis_consumer.consumers import ImageFileConsumer
+from redis_consumer.consumers import TensorFlowServingConsumer
 from redis_consumer import utils
 from redis_consumer import settings
 from redis_consumer import processing
 
 
-class MultiplexConsumer(ImageFileConsumer):
+class MultiplexConsumer(TensorFlowServingConsumer):
     """Consumes image files and uploads the results"""
+
+    def is_valid_hash(self, redis_hash):
+        if redis_hash is None:
+            return False
+
+        fname = str(self.redis.hget(redis_hash, 'input_file_name'))
+        return not fname.lower().endswith('.zip')
 
     def _consume(self, redis_hash):
         start = timeit.default_timer()

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -155,8 +155,8 @@ BIRTH = config('BIRTH', default=0.95, cast=float)
 DEATH = config('DEATH', default=0.95, cast=float)
 NEIGHBORHOOD_SCALE_SIZE = config('NEIGHBORHOOD_SCALE_SIZE', default=30, cast=int)
 
-MAX_SCALE = config('MAX_SCALE', default=3, cast=int)
-MIN_SCALE = 1 / MAX_SCALE
+MAX_SCALE = config('MAX_SCALE', default=3, cast=float)
+MIN_SCALE = config('MIN_SCALE', default=1 / MAX_SCALE, cast=float)
 
 # Scale detection settings
 SCALE_DETECT_MODEL = config('SCALE_DETECT_MODEL', default='ScaleDetection:1')

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -155,6 +155,9 @@ BIRTH = config('BIRTH', default=0.95, cast=float)
 DEATH = config('DEATH', default=0.95, cast=float)
 NEIGHBORHOOD_SCALE_SIZE = config('NEIGHBORHOOD_SCALE_SIZE', default=30, cast=int)
 
+MAX_SCALE = config('MAX_SCALE', default=3, cast=int)
+MIN_SCALE = 1 / MAX_SCALE
+
 # Scale detection settings
 SCALE_DETECT_MODEL = config('SCALE_DETECT_MODEL', default='ScaleDetection:1')
 SCALE_DETECT_ENABLED = config('SCALE_DETECT_ENABLED', default=False, cast=bool)


### PR DESCRIPTION
This PR fixes a bug that allows a user to set the `scale` value to very large values which will crash the consumer. Instead, the value is compared with new environment variables `MIN_SCALE` and `MAX_SCALE` and a `ValueError` is raised if the value is outside the range.

This introduces a new method `get_image_scale` on the base class `TensorFlowServingConsumer`, which can be called by the downstream classes.  `detect_scale` is also defined in the base class, though it just returns a default value of `1` and relies on the child classes to implement any detection via models.  This required changing the base class of `MultiplexConsumer` to `TensorFlowServingConsumer`.