### PR TITLE
Padding bugfix

### DIFF
--- a/redis_consumer/consumers/base_consumer.py
+++ b/redis_consumer/consumers/base_consumer.py
@@ -516,6 +516,8 @@ class TensorFlowServingConsumer(Consumer):
                         pad_width.append((diff // 2, diff // 2 + 1))
                     else:
                         pad_width.append((diff // 2, diff // 2))
+                else:
+                    pad_width.append((0, 0))
             else:
                 pad_width.append((0, 0))
 

--- a/redis_consumer/consumers/base_consumer.py
+++ b/redis_consumer/consumers/base_consumer.py
@@ -511,10 +511,11 @@ class TensorFlowServingConsumer(Consumer):
                 else:
                     diff = model_shape[model_ndim - 2] - image.shape[i]
 
-                if diff % 2:
-                    pad_width.append((diff // 2, diff // 2 + 1))
-                else:
-                    pad_width.append((diff // 2, diff // 2))
+                if diff > 0:
+                    if diff % 2:
+                        pad_width.append((diff // 2, diff // 2 + 1))
+                    else:
+                        pad_width.append((diff // 2, diff // 2))
             else:
                 pad_width.append((0, 0))
 

--- a/redis_consumer/consumers/base_consumer_test.py
+++ b/redis_consumer/consumers/base_consumer_test.py
@@ -350,6 +350,7 @@ class TestTensorFlowServingConsumer(object):
             (300, 300, 1),
             (257, 301, 1),
             (65, 127, 1),
+            (127, 129, 1),
         ]
         grpc_funcs = (grpc_image, grpc_image_list)
         untiles = (False, True)


### PR DESCRIPTION
The current `predict_small_image` function assumes that small images small across both dimensions. This leads to an error with a negative pad value if one of the dimensions is appropriately sized and the other is not. 

I added in logic to add zero padding for dimensions that are at the threshold, with non-zero padding for the small side of the image. 