### PR TITLE
Resize outputs to target shape in `save_output`.

### DIFF
--- a/redis_consumer/consumers/base_consumer.py
+++ b/redis_consumer/consumers/base_consumer.py
@@ -741,11 +741,16 @@ class TensorFlowServingConsumer(Consumer):
 
             # Rescale image to original size before sending back to user
             outpaths = []
+            added_batch = False
             for i, im in enumerate(image):
                 if output_shape:
-                    im = np.expand_dims(im, axis=0)  # add batch for resize
+                    if im.shape[0] != 1:
+                        added_batch = True
+                        im = np.expand_dims(im, axis=0)  # add batch for resize
                     self.logger.info('Resizing image of shape %s to %s', im.shape, output_shape)
-                    im = resize(im, output_shape)[0]
+                    im = resize(im, output_shape, labeled_image=True)
+                    if added_batch:
+                        im = im[0]
 
                 outpaths.extend(utils.save_numpy_array(
                     im,

--- a/redis_consumer/consumers/image_consumer.py
+++ b/redis_consumer/consumers/image_consumer.py
@@ -149,6 +149,9 @@ class ImageFileConsumer(TensorFlowServingConsumer):
         # Calculate scale of image and rescale
         scale = hvals.get('scale', '')
         scale = self.get_image_scale(scale, image, redis_hash)
+
+        original_shape = image.shape
+
         image = utils.rescale(image, scale)
 
         # Save shape value for postprocessing purposes
@@ -202,7 +205,8 @@ class ImageFileConsumer(TensorFlowServingConsumer):
         self.update_key(redis_hash, {'status': 'saving-results'})
 
         save_name = hvals.get('original_name', fname)
-        dest, output_url = self.save_output(image, redis_hash, save_name, scale)
+        dest, output_url = self.save_output(
+            image, redis_hash, save_name, original_shape[:-1])
 
         # Update redis with the final results
         t = timeit.default_timer() - start

--- a/redis_consumer/consumers/image_consumer.py
+++ b/redis_consumer/consumers/image_consumer.py
@@ -205,6 +205,7 @@ class ImageFileConsumer(TensorFlowServingConsumer):
         self.update_key(redis_hash, {'status': 'saving-results'})
 
         save_name = hvals.get('original_name', fname)
+        image = np.expand_dims(image, axis=-1)
         dest, output_url = self.save_output(
             image, redis_hash, save_name, original_shape[:-1])
 

--- a/redis_consumer/consumers/image_consumer.py
+++ b/redis_consumer/consumers/image_consumer.py
@@ -205,7 +205,13 @@ class ImageFileConsumer(TensorFlowServingConsumer):
         self.update_key(redis_hash, {'status': 'saving-results'})
 
         save_name = hvals.get('original_name', fname)
-        image = np.expand_dims(image, axis=-1)
+
+        if isinstance(image, list):
+            for i, img in enumerate(image):
+                if img.shape[-1] != 1:
+                    image[i] = np.expand_dims(img, axis=-1)
+        elif image.shape[-1] != 1:
+            image = np.expand_dims(image, axis=-1)
         dest, output_url = self.save_output(
             image, redis_hash, save_name, original_shape[:-1])
 

--- a/redis_consumer/consumers/multiplex_consumer.py
+++ b/redis_consumer/consumers/multiplex_consumer.py
@@ -110,6 +110,8 @@ class MultiplexConsumer(TensorFlowServingConsumer):
         scale = hvals.get('scale', '')
         scale = self.get_image_scale(scale, image, redis_hash)
 
+        original_shape = image.shape
+
         # Rescale each channel of the image
         image = utils.rescale(image, scale)
         image = np.expand_dims(image, axis=0)  # add in the batch dim
@@ -131,7 +133,8 @@ class MultiplexConsumer(TensorFlowServingConsumer):
         self.update_key(redis_hash, {'status': 'saving-results'})
 
         save_name = hvals.get('original_name', fname)
-        dest, output_url = self.save_output(image, redis_hash, save_name, scale)
+        dest, output_url = self.save_output(
+            image, redis_hash, save_name, original_shape[:-1])
 
         # Update redis with the final results
         t = timeit.default_timer() - start


### PR DESCRIPTION
Use `deepcell_utils.resize` instead of `skimage.transform.rescale`  in `save_output`. This guarantees the output shape will be the same as the input image.

Fixes #145