### PR TITLE
Mock MultiplexConsumer postprocessing during tests to reduce 80% of test time.

### DIFF
--- a/redis_consumer/consumers/image_consumer_test.py
+++ b/redis_consumer/consumers/image_consumer_test.py
@@ -36,7 +36,8 @@ import pytest
 
 from redis_consumer import consumers
 from redis_consumer import settings
-from redis_consumer.testing_utils import DummyStorage, redis_client, _get_image
+from redis_consumer.testing_utils import DummyStorage, redis_client
+from redis_consumer.testing_utils import _get_image, make_model_metadata_of_size
 
 
 class TestImageFileConsumer(object):
@@ -143,17 +144,6 @@ class TestImageFileConsumer(object):
 
         def grpc_image_list(data, *args, **kwargs):  # pylint: disable=W0613
             return [data, data]
-
-        def make_model_metadata_of_size(model_shape=(-1, 256, 256, 1)):
-
-            def get_model_metadata(model_name, model_version):
-                return [{
-                    'in_tensor_name': 'image',
-                    'in_tensor_dtype': 'DT_FLOAT',
-                    'in_tensor_shape': ','.join(str(s) for s in model_shape),
-                }]
-
-            return get_model_metadata
 
         mocker.patch.object(consumer, 'detect_label', lambda x: 1)
         mocker.patch.object(consumer, 'detect_scale', lambda x: 1)

--- a/redis_consumer/consumers/image_consumer_test.py
+++ b/redis_consumer/consumers/image_consumer_test.py
@@ -154,6 +154,8 @@ class TestImageFileConsumer(object):
             (-1, 600, 600, 1),  # image too small, pad
             (-1, 300, 300, 1),  # image is exactly the right size
             (-1, 150, 150, 1),  # image too big, tile
+            (-1, 150, 600, 1),  # image has one size too small, one size too big
+            (-1, 600, 150, 1),  # image has one size too small, one size too big
         ]
 
         empty_data = {'input_file_name': 'file.tiff'}

--- a/redis_consumer/consumers/multiplex_consumer_test.py
+++ b/redis_consumer/consumers/multiplex_consumer_test.py
@@ -36,6 +36,7 @@ import pytest
 
 from redis_consumer import consumers
 from redis_consumer.testing_utils import redis_client, DummyStorage
+from redis_consumer.testing_utils import make_model_metadata_of_size
 
 
 class TestMultiplexConsumer(object):
@@ -56,16 +57,6 @@ class TestMultiplexConsumer(object):
 
     def test__consume(self, mocker, redis_client):
         # pylint: disable=W0613
-
-        def make_model_metadata_of_size(model_shape=(-1, 256, 256, 2)):
-
-            def get_model_metadata(model_name, model_version):
-                return [{
-                    'in_tensor_name': 'image',
-                    'in_tensor_dtype': 'DT_FLOAT',
-                    'in_tensor_shape': ','.join(str(s) for s in model_shape),
-                }]
-            return get_model_metadata
 
         def make_grpc_image(model_shape=(-1, 256, 256, 2)):
             # pylint: disable=E1101

--- a/redis_consumer/consumers/multiplex_consumer_test.py
+++ b/redis_consumer/consumers/multiplex_consumer_test.py
@@ -117,6 +117,8 @@ class TestMultiplexConsumer(object):
             grpc_image = make_grpc_image(model_shape)
             mocker.patch.object(consumer, 'get_model_metadata', metadata)
             mocker.patch.object(consumer, 'grpc_image', grpc_image)
+            mocker.patch.object(consumer, 'postprocess',
+                                lambda *x: np.random.randint(0, 5, size=(300, 300, 1)))
 
             data = job_data.copy()
             data['scale'] = scale

--- a/redis_consumer/consumers/multiplex_consumer_test.py
+++ b/redis_consumer/consumers/multiplex_consumer_test.py
@@ -82,7 +82,7 @@ class TestMultiplexConsumer(object):
             (-1, 150, 150, 2),  # image too big, tile
         ]
 
-        scales = ['.9', '']
+        scales = ['.9', '1.1', '']
 
         job_data = {
             'input_file_name': 'file.tiff',

--- a/redis_consumer/consumers/multiplex_consumer_test.py
+++ b/redis_consumer/consumers/multiplex_consumer_test.py
@@ -147,7 +147,7 @@ class TestMultiplexConsumer(object):
             mocker.patch.object(consumer, 'grpc_image', grpc_image)
 
             data = job_data.copy()
-            data['scale'] = scale
+            data['scale'] = '1'
 
             redis_client.hmset(test_hash, data)
             with pytest.raises(ValueError, match='Invalid image shape'):

--- a/redis_consumer/consumers/multiplex_consumer_test.py
+++ b/redis_consumer/consumers/multiplex_consumer_test.py
@@ -84,6 +84,8 @@ class TestMultiplexConsumer(object):
             (-1, 600, 600, 2),  # image too small, pad
             (-1, 300, 300, 2),  # image is exactly the right size
             (-1, 150, 150, 2),  # image too big, tile
+            (-1, 150, 600, 2),  # image has one size too small, one size too big
+            (-1, 600, 150, 2),  # image has one size too small, one size too big
         ]
 
         scales = ['.9', '1.1', '']

--- a/redis_consumer/testing_utils.py
+++ b/redis_consumer/testing_utils.py
@@ -84,3 +84,14 @@ class DummyStorage(object):
 
     def get_public_url(self, zip_path):
         return 'blob.public_url'
+
+
+def make_model_metadata_of_size(model_shape=(-1, 256, 256, 2)):
+
+    def get_model_metadata(model_name, model_version):  # pylint: disable=unused-argument
+        return [{
+            'in_tensor_name': 'image',
+            'in_tensor_dtype': 'DT_FLOAT',
+            'in_tensor_shape': ','.join(str(s) for s in model_shape),
+        }]
+    return get_model_metadata


### PR DESCRIPTION
* Mock `MultiplexConsumer.postprocess` during the consumer tests to reduce ~80% of total test time (20s -> 4s).
* Move `make_model_metadata_of_size` to `testing_utils.py` to be re-used in each consumer.
* Add model shapes that straddle either side of too big and too small to test suite.
* General code readability changes.