### PR TITLE
Revert output filename suffix.

### DIFF
--- a/redis_consumer/consumers/base_consumer.py
+++ b/redis_consumer/consumers/base_consumer.py
@@ -754,7 +754,7 @@ class TensorFlowServingConsumer(Consumer):
 
                 outpaths.extend(utils.save_numpy_array(
                     im,
-                    name='{}_{}'.format(name, i),
+                    name=str(name),
                     subdir=subdir, output_dir=tempdir))
 
             # Save each prediction image as zip file


### PR DESCRIPTION
A bug was introduced causing the output filenames to be changed from: `input_filename_feature_0.tif` to `input_filename_0_feature_0.tif`.