### PR TITLE
Select compartment via MULTIPLEX_COMPARTMENT environment variable.

### DIFF
--- a/redis_consumer/consumers/multiplex_consumer.py
+++ b/redis_consumer/consumers/multiplex_consumer.py
@@ -117,6 +117,7 @@ class MultiplexConsumer(TensorFlowServingConsumer):
                                 MultiplexSegmentation)
 
         results = app.predict(image, batch_size=None,
+                              compartment=settings.MULTIPLEX_COMPARTMENT,
                               image_mpp=scale * app.model_mpp)
 
         # Save the post-processed results to a file

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -113,6 +113,7 @@ LABEL_DETECT_ENABLED = config('LABEL_DETECT_ENABLED', default=False, cast=bool)
 
 # Multiplex model Settings
 MULTIPLEX_MODEL = config('MULTIPLEX_MODEL', default='MultiplexSegmentation:5', cast=str)
+MULTIPLEX_COMPARTMENT = config('MULTIPLEX_COMPARTMENT', default='whole-cell')
 
 # Set default models based on label type
 MODEL_CHOICES = {


### PR DESCRIPTION
This PR allows the compartment to be passed to `.predict` using the `MULTIPLEX_COMPARTMENT` environment variable. The outputs are defined by the `MultiplexApplication` but will be multiple files in the same zip archive.

However, this introduces an incompatibility with `kiosk-imagej-plugin` which can [only open a single tiff file](https://imagej.nih.gov/ij/developer/api/ij/io/Opener.html#openURL-java.lang.String-) from the zip file.

Fixes #136.