### PR TITLE
Refactor MultiplexConsumer to MesmerConsumer.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/redis_consumer/consumers/__init__.py
+++ b/redis_consumer/consumers/__init__.py
@@ -35,7 +35,7 @@ from redis_consumer.consumers.base_consumer import ZipFileConsumer
 # Custom Workflow consumers
 from redis_consumer.consumers.segmentation_consumer import SegmentationConsumer
 from redis_consumer.consumers.tracking_consumer import TrackingConsumer
-from redis_consumer.consumers.multiplex_consumer import MultiplexConsumer
+from redis_consumer.consumers.mesmer_consumer import MesmerConsumer
 # TODO: Import future custom Consumer classes.
 
 
@@ -44,9 +44,14 @@ CONSUMERS = {
     'segmentation': SegmentationConsumer,
     'zip': ZipFileConsumer,
     'tracking': TrackingConsumer,
-    'multiplex': MultiplexConsumer,
+    'multiplex': MesmerConsumer,  # deprecated, use "mesmer" instead.
+    'mesmer': MesmerConsumer,
     # TODO: Add future custom Consumer classes here.
 }
+
+
+# Backwards compatibility for MultiplexConsumer
+MultiplexConsumer = MesmerConsumer
 
 
 del absolute_import

--- a/redis_consumer/consumers/mesmer_consumer.py
+++ b/redis_consumer/consumers/mesmer_consumer.py
@@ -117,6 +117,7 @@ class MesmerConsumer(TensorFlowServingConsumer):
                                 MultiplexSegmentation)
 
         results = app.predict(image, batch_size=None,
+                              compartment=settings.MESMER_COMPARTMENT,
                               image_mpp=scale * app.model_mpp)
 
         # Save the post-processed results to a file

--- a/redis_consumer/consumers/mesmer_consumer.py
+++ b/redis_consumer/consumers/mesmer_consumer.py
@@ -116,8 +116,9 @@ class MesmerConsumer(TensorFlowServingConsumer):
         app = self.get_grpc_app(settings.MESMER_MODEL,
                                 MultiplexSegmentation)
 
+        compartment = hvals.get('compartment', settings.MESMER_COMPARTMENT)
         results = app.predict(image, batch_size=None,
-                              compartment=settings.MESMER_COMPARTMENT,
+                              compartment=compartment,
                               image_mpp=scale * app.model_mpp)
 
         # Save the post-processed results to a file

--- a/redis_consumer/consumers/mesmer_consumer.py
+++ b/redis_consumer/consumers/mesmer_consumer.py
@@ -86,7 +86,7 @@ class MesmerConsumer(TensorFlowServingConsumer):
         })
 
         # Get model_name and version
-        model_name, model_version = settings.MULTIPLEX_MODEL.split(':')
+        model_name, model_version = settings.MESMER_MODEL.split(':')
 
         _ = timeit.default_timer()
 
@@ -113,7 +113,7 @@ class MesmerConsumer(TensorFlowServingConsumer):
         image = self.validate_model_input(image, model_name, model_version)
 
         # Send data to the model
-        app = self.get_grpc_app(settings.MULTIPLEX_MODEL,
+        app = self.get_grpc_app(settings.MESMER_MODEL,
                                 MultiplexSegmentation)
 
         results = app.predict(image, batch_size=None,

--- a/redis_consumer/consumers/mesmer_consumer.py
+++ b/redis_consumer/consumers/mesmer_consumer.py
@@ -38,7 +38,7 @@ from redis_consumer.consumers import TensorFlowServingConsumer
 from redis_consumer import settings
 
 
-class MultiplexConsumer(TensorFlowServingConsumer):
+class MesmerConsumer(TensorFlowServingConsumer):
     """Consumes image files and uploads the results"""
 
     def detect_scale(self, image):

--- a/redis_consumer/consumers/mesmer_consumer.py
+++ b/redis_consumer/consumers/mesmer_consumer.py
@@ -23,7 +23,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ============================================================================
-"""MultiplexConsumer class for consuming multiplex segmentation jobs."""
+"""MesmerConsumer class for consuming Mesmer whole cell segmentation jobs."""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -32,7 +32,7 @@ import timeit
 
 import numpy as np
 
-from deepcell.applications import ScaleDetection, MultiplexSegmentation
+from deepcell.applications import ScaleDetection, Mesmer
 
 from redis_consumer.consumers import TensorFlowServingConsumer
 from redis_consumer import settings
@@ -113,8 +113,7 @@ class MesmerConsumer(TensorFlowServingConsumer):
         image = self.validate_model_input(image, model_name, model_version)
 
         # Send data to the model
-        app = self.get_grpc_app(settings.MESMER_MODEL,
-                                MultiplexSegmentation)
+        app = self.get_grpc_app(settings.MESMER_MODEL, Mesmer)
 
         compartment = hvals.get('compartment', settings.MESMER_COMPARTMENT)
         results = app.predict(image, batch_size=None,

--- a/redis_consumer/consumers/mesmer_consumer_test.py
+++ b/redis_consumer/consumers/mesmer_consumer_test.py
@@ -23,7 +23,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ============================================================================
-"""Tests for MultiplexConsumer"""
+"""Tests for MesmerConsumer"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -40,13 +40,13 @@ from redis_consumer.testing_utils import DummyStorage
 from redis_consumer.testing_utils import redis_client
 
 
-class TestMultiplexConsumer(object):
+class TestMesmerConsumer(object):
     # pylint: disable=R0201,W0621
 
     def test_detect_scale(self, mocker, redis_client):
         # pylint: disable=W0613
         shape = (1, 256, 256, 1)
-        consumer = consumers.MultiplexConsumer(redis_client, None, 'q')
+        consumer = consumers.MesmerConsumer(redis_client, None, 'q')
 
         image = _get_image(shape[1] * 2, shape[2] * 2, shape[3])
 
@@ -72,7 +72,7 @@ class TestMultiplexConsumer(object):
         queue = 'q'
         storage = DummyStorage()
 
-        consumer = consumers.MultiplexConsumer(redis_client, storage, queue)
+        consumer = consumers.MesmerConsumer(redis_client, storage, queue)
 
         empty_data = {'input_file_name': 'file.tiff'}
 
@@ -94,7 +94,7 @@ class TestMultiplexConsumer(object):
         queue = 'multiplex'
         storage = DummyStorage()
 
-        consumer = consumers.MultiplexConsumer(redis_client, storage, queue)
+        consumer = consumers.MesmerConsumer(redis_client, storage, queue)
 
         empty_data = {'input_file_name': 'file.tiff'}
 

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -111,8 +111,10 @@ MIN_SCALE = config('MIN_SCALE', default=1 / MAX_SCALE, cast=float)
 LABEL_DETECT_MODEL = config('LABEL_DETECT_MODEL', default='LabelDetection:1', cast=str)
 LABEL_DETECT_ENABLED = config('LABEL_DETECT_ENABLED', default=False, cast=bool)
 
-# Multiplex model Settings
+# Mesmer model Settings
+# deprecated model name, use MESMER_MODEL instead.
 MULTIPLEX_MODEL = config('MULTIPLEX_MODEL', default='MultiplexSegmentation:5', cast=str)
+MESMER_MODEL = config('MESMER_MODEL', default=MULTIPLEX_MODEL, cast=str)
 
 # Set default models based on label type
 MODEL_CHOICES = {

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -115,6 +115,7 @@ LABEL_DETECT_ENABLED = config('LABEL_DETECT_ENABLED', default=False, cast=bool)
 # deprecated model name, use MESMER_MODEL instead.
 MULTIPLEX_MODEL = config('MULTIPLEX_MODEL', default='MultiplexSegmentation:5', cast=str)
 MESMER_MODEL = config('MESMER_MODEL', default=MULTIPLEX_MODEL, cast=str)
+MESMER_COMPARTMENT = config('MESMER_COMPARTMENT', default='whole-cell')
 
 # Set default models based on label type
 MODEL_CHOICES = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # deepcell packages
-deepcell-cpu>=0.8.6
+deepcell-cpu>=0.9.0
 deepcell-tracking==0.3.1
-deepcell-toolbox>=0.8.6
+deepcell-toolbox>=0.9.0
 tensorflow-cpu
 scikit-image>=0.14.5,<0.17.0
 numpy>=1.16.6


### PR DESCRIPTION
Refactor consumer names and the `MULTIPLEX_MODEL` to `MESMER_MODEL`.

This PR also allows the compartment to be passed to `.predict` using the `MESMER_COMPARTMENT` environment variable. The outputs are defined by `deepcell.applications.Mesmer` but will be multiple files in the same zip archive.

However, this introduces an incompatibility with `kiosk-imagej-plugin` which can [only open a single tiff file](https://imagej.nih.gov/ij/developer/api/ij/io/Opener.html#openURL-java.lang.String-) from the zip file.

`deepcell` is also updated to 0.9.0 which supports the `Mesmer` application and drops support for Python 3.5.

Fixes #136.