### PR TITLE
Allow optional channels to be defined to select a subset of channels for the job.

### DIFF
--- a/redis_consumer/consumers/base_consumer_test.py
+++ b/redis_consumer/consumers/base_consumer_test.py
@@ -318,7 +318,7 @@ class TestTensorFlowServingConsumer(object):
         # test too few and too many channels
         invalid_channels = [
             [3],  # too few channels
-            list(range(image.shape[-1] + 1)), # too many channels
+            list(range(image.shape[-1] + 1)),  # too many channels
             [0, 100],  # channel out of range
         ]
         for c in invalid_channels:

--- a/redis_consumer/consumers/base_consumer_test.py
+++ b/redis_consumer/consumers/base_consumer_test.py
@@ -250,7 +250,7 @@ class TestTensorFlowServingConsumer(object):
         valid_input_shapes = [
             (1, 32, 32, 1),  # exact same shape
             (1, 64, 64, 1),  # bigger
-            (1, 32, 32, 1),  # smaller
+            (1, 16, 16, 1),  # smaller
             (1, 33, 31, 1),  # mixed
         ]
         for shape in valid_input_shapes:
@@ -290,9 +290,10 @@ class TestTensorFlowServingConsumer(object):
             np.testing.assert_array_equal(i, j)
 
         # metadata and image counts do not match
-        with pytest.raises(ValueError):
-            image = [np.ones(s) for s in valid_input_shapes[:count]]
-            consumer.validate_model_input(img, 'model', '1')
+        for c in [count + 1, count - 1]:
+            with pytest.raises(ValueError):
+                image = [np.ones(s) for s in valid_input_shapes[:c]]
+                consumer.validate_model_input(image, 'model', '1')
 
         # correct number of inputs, but one invalid entry
         with pytest.raises(ValueError):

--- a/redis_consumer/consumers/mesmer_consumer.py
+++ b/redis_consumer/consumers/mesmer_consumer.py
@@ -110,7 +110,13 @@ class MesmerConsumer(TensorFlowServingConsumer):
         scale = self.get_image_scale(scale, image, redis_hash)
 
         # Validate input image
-        image = self.validate_model_input(image, model_name, model_version)
+        if hvals.get('channels'):
+            channels = [int(c) for c in hvals.get('channels').split(',')]
+        else:
+            channels = None
+
+        image = self.validate_model_input(image, model_name, model_version,
+                                          channels=channels)
 
         # Send data to the model
         app = self.get_grpc_app(settings.MESMER_MODEL, Mesmer)

--- a/redis_consumer/consumers/mesmer_consumer_test.py
+++ b/redis_consumer/consumers/mesmer_consumer_test.py
@@ -109,9 +109,9 @@ class TestMesmerConsumer(object):
             )
         )
 
-        mocker.patch.object(consumer, 'get_grpc_app', lambda *x: mock_app)
-        mocker.patch.object(consumer, 'get_image_scale', lambda *x: 1)
-        mocker.patch.object(consumer, 'validate_model_input', lambda *x: x[0])
+        mocker.patch.object(consumer, 'get_grpc_app', lambda *x, **_: mock_app)
+        mocker.patch.object(consumer, 'get_image_scale', lambda *x, **_: 1)
+        mocker.patch.object(consumer, 'validate_model_input', lambda *x, **_: x[0])
 
         test_hash = 'some hash'
 

--- a/redis_consumer/consumers/segmentation_consumer.py
+++ b/redis_consumer/consumers/segmentation_consumer.py
@@ -107,6 +107,12 @@ class SegmentationConsumer(TensorFlowServingConsumer):
         image = self.download_image(fname)
         image = np.expand_dims(image, axis=0)  # add a batch dimension
 
+        # Validate input image
+        if hvals.get('channels'):
+            channels = [int(c) for c in hvals.get('channels').split(',')]
+        else:
+            channels = None
+
         # Pre-process data before sending to the model
         self.update_key(redis_hash, {
             'status': 'pre-processing',
@@ -127,7 +133,8 @@ class SegmentationConsumer(TensorFlowServingConsumer):
         model_name, model_version = model.split(':')
 
         # Validate input image
-        image = self.validate_model_input(image, model_name, model_version)
+        image = self.validate_model_input(image, model_name, model_version,
+                                          channels=channels)
 
         # Send data to the model
         self.update_key(redis_hash, {'status': 'predicting'})

--- a/redis_consumer/consumers/segmentation_consumer_test.py
+++ b/redis_consumer/consumers/segmentation_consumer_test.py
@@ -138,10 +138,10 @@ class TestSegmentationConsumer(object):
             )
         )
 
-        mocker.patch.object(consumer, 'get_grpc_app', lambda *x: mock_app)
-        mocker.patch.object(consumer, 'get_image_scale', lambda *x: 1)
-        mocker.patch.object(consumer, 'get_image_label', lambda *x: 1)
-        mocker.patch.object(consumer, 'validate_model_input', lambda *x: True)
+        mocker.patch.object(consumer, 'get_grpc_app', lambda *x, **_: mock_app)
+        mocker.patch.object(consumer, 'get_image_scale', lambda *x, **_: 1)
+        mocker.patch.object(consumer, 'get_image_label', lambda *x, **_: 1)
+        mocker.patch.object(consumer, 'validate_model_input', lambda *x, **_: True)
 
         test_hash = 'some hash'
 

--- a/redis_consumer/consumers/tracking_consumer.py
+++ b/redis_consumer/consumers/tracking_consumer.py
@@ -127,7 +127,7 @@ class TrackingConsumer(TensorFlowServingConsumer):
                 'created_at': current_timestamp,
                 'updated_at': current_timestamp,
                 'url': upload_file_url,
-                'channels': hvalues.get('channels'),
+                'channels': hvalues.get('channels', ''),
             }
 
             # make a hash for this frame

--- a/redis_consumer/consumers/tracking_consumer.py
+++ b/redis_consumer/consumers/tracking_consumer.py
@@ -126,7 +126,8 @@ class TrackingConsumer(TensorFlowServingConsumer):
                 'status': 'new',
                 'created_at': current_timestamp,
                 'updated_at': current_timestamp,
-                'url': upload_file_url
+                'url': upload_file_url,
+                'channels': hvalues.get('channels'),
             }
 
             # make a hash for this frame


### PR DESCRIPTION
`channels` is expected to be a comma-separated string of integers, which allows the consumer to select a subset of channels from the image and re-orders them as input to the model.

For example, if an image has 4 channels, then a `channels` value of `"0"` selects the first channel of the image, while `"2,3"` selects the final 2 channels of the image.  A value of `"3,2"` also selects the final two images, but reorders them so that channel 3 is now in the channel 0 spot.