### PR TITLE
Validate image is smaller than MAX_IMAGE_HEIGHT and MAX_IMAGE_WIDTH

### DIFF
--- a/redis_consumer/consumers/base_consumer.py
+++ b/redis_consumer/consumers/base_consumer.py
@@ -297,7 +297,7 @@ class TensorFlowServingConsumer(Consumer):
                 raise ValueError(errtext)
 
             if (img.shape[rank - 2] > settings.MAX_IMAGE_WIDTH or
-                img.shape[rank - 3] > settings.MAX_IMAGE_HEIGHT):
+                    img.shape[rank - 3] > settings.MAX_IMAGE_HEIGHT):
                 raise ValueError(
                     'Input image is larger than the maximum '
                     'supported image size of ({}, {}). Got {}.'.format(

--- a/redis_consumer/consumers/base_consumer.py
+++ b/redis_consumer/consumers/base_consumer.py
@@ -296,6 +296,16 @@ class TensorFlowServingConsumer(Consumer):
             if img.shape[rank - 1] != shape[-1]:
                 raise ValueError(errtext)
 
+            if (img.shape[rank - 2] > settings.MAX_IMAGE_WIDTH or
+                img.shape[rank - 3] > settings.MAX_IMAGE_HEIGHT):
+                raise ValueError(
+                    'Input image is larger than the maximum '
+                    'supported image size of ({}, {}). Got {}.'.format(
+                        settings.MAX_IMAGE_WIDTH,
+                        settings.MAX_IMAGE_HEIGHT,
+                        img.shape
+                    ))
+
             validated.append(img)
 
         return validated[0] if len(validated) == 1 else validated

--- a/redis_consumer/consumers/base_consumer_test.py
+++ b/redis_consumer/consumers/base_consumer_test.py
@@ -272,6 +272,8 @@ class TestTensorFlowServingConsumer(object):
             (1, 32, 32, 32, 1),  # rank too large
             (1, 32, 32, 2),  # wrong channels
             (1, 16, 64, 2),  # wrong channels with mixed shape
+            (1, 32, settings.MAX_IMAGE_WIDTH + 1, 1),  # width too large
+            (1, settings.MAX_IMAGE_HEIGHT + 1, 32, 1),  # height too large
         ]
         for shape in invalid_input_shapes:
             img = np.ones(shape)


### PR DESCRIPTION
This size check was accidentally dropped when we migrated to using `deepcell` as the job definition. This PR re-introduces the check in the `validate_model_input` function.