### PR TITLE
Add predicting status update to MesmerConsumer

### DIFF
--- a/redis_consumer/consumers/mesmer_consumer.py
+++ b/redis_consumer/consumers/mesmer_consumer.py
@@ -119,6 +119,8 @@ class MesmerConsumer(TensorFlowServingConsumer):
                                           channels=channels)
 
         # Send data to the model
+        self.update_key(redis_hash, {'status': 'predicting'})
+
         app = self.get_grpc_app(settings.MESMER_MODEL, Mesmer)
 
         compartment = hvals.get('compartment', settings.MESMER_COMPARTMENT)


### PR DESCRIPTION
Somewhere the `predicting` status stopped getting set for `MesmerConsumer`.

This PR simply adds it back in right before the application object is created, just like in `SegmentationConsumer`.