### PR TITLE
TrackingConsumer throws an error if input has more frames than MAX_IMAGE_FRAMES

### DIFF
--- a/redis_consumer/consumers/tracking_consumer.py
+++ b/redis_consumer/consumers/tracking_consumer.py
@@ -103,6 +103,11 @@ class TrackingConsumer(TensorFlowServingConsumer):
         remaining_hashes = set()
         frames = {}
 
+        if num_frames > settings.MAX_IMAGE_FRAMES:
+            raise ValueError('This tiff file has {} frames but the maximum '
+                             'number of allowed frames is {}.'.format(
+                                 num_frames, settings.MAX_IMAGE_FRAMES))
+
         self.logger.debug('Got tiffstack shape %s.', tiff_stack.shape)
 
         uid = uuid.uuid4().hex

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -45,6 +45,7 @@ CONSUMER_TYPE = config('CONSUMER_TYPE', default='image')
 MAX_RETRY = config('MAX_RETRY', default=5, cast=int)
 MAX_IMAGE_HEIGHT = config('MAX_IMAGE_HEIGHT', default=2048, cast=int)
 MAX_IMAGE_WIDTH = config('MAX_IMAGE_WIDTH', default=2048, cast=int)
+MAX_IMAGE_FRAMES = config('MAX_IMAGE_FRAMES', default=60, cast=int)
 
 # Redis client connection
 REDIS_HOST = config('REDIS_HOST', default='redis-master')


### PR DESCRIPTION
Introduces new environment variable `MAX_IMAGE_FRAMES` which the `TrackingConsumer` compares its input against. If the input image has more frames, then an error is thrown.

This is due to a 1200 frame movie being uploaded causing a crash loop during tracking. (Segmentation of all 1200 frames worked as expected).