### PR TITLE
Add new `detect_dimension_order` to detect the dim ordering string.

### DIFF
--- a/redis_consumer/consumers/mesmer_consumer.py
+++ b/redis_consumer/consumers/mesmer_consumer.py
@@ -109,6 +109,12 @@ class MesmerConsumer(TensorFlowServingConsumer):
         scale = hvals.get('scale', '')
         scale = self.get_image_scale(scale, image, redis_hash)
 
+        # detect dimension order and add to redis
+        dim_order = self.detect_dimension_order(image, model_name, model_version)
+        self.update_key(redis_hash, {
+            'dim_order': ','.join(dim_order)
+        })
+
         # Validate input image
         if hvals.get('channels'):
             channels = [int(c) for c in hvals.get('channels').split(',')]

--- a/redis_consumer/consumers/mesmer_consumer_test.py
+++ b/redis_consumer/consumers/mesmer_consumer_test.py
@@ -112,6 +112,7 @@ class TestMesmerConsumer(object):
         mocker.patch.object(consumer, 'get_grpc_app', lambda *x, **_: mock_app)
         mocker.patch.object(consumer, 'get_image_scale', lambda *x, **_: 1)
         mocker.patch.object(consumer, 'validate_model_input', lambda *x, **_: x[0])
+        mocker.patch.object(consumer, 'detect_dimension_order', lambda *x, **_: 'YXC')
 
         test_hash = 'some hash'
 

--- a/redis_consumer/consumers/segmentation_consumer.py
+++ b/redis_consumer/consumers/segmentation_consumer.py
@@ -132,6 +132,12 @@ class SegmentationConsumer(TensorFlowServingConsumer):
 
         model_name, model_version = model.split(':')
 
+        # detect dimension order and add to redis
+        dim_order = self.detect_dimension_order(image, model_name, model_version)
+        self.update_key(redis_hash, {
+            'dim_order': ','.join(dim_order)
+        })
+
         # Validate input image
         image = self.validate_model_input(image, model_name, model_version,
                                           channels=channels)

--- a/redis_consumer/consumers/segmentation_consumer_test.py
+++ b/redis_consumer/consumers/segmentation_consumer_test.py
@@ -142,6 +142,7 @@ class TestSegmentationConsumer(object):
         mocker.patch.object(consumer, 'get_image_scale', lambda *x, **_: 1)
         mocker.patch.object(consumer, 'get_image_label', lambda *x, **_: 1)
         mocker.patch.object(consumer, 'validate_model_input', lambda *x, **_: True)
+        mocker.patch.object(consumer, 'detect_dimension_order', lambda *x, **_: 'YXC')
 
         test_hash = 'some hash'
 


### PR DESCRIPTION
Detects the dimension ordering for 2D and 3D data for channels first or channels last, and placed in Redis under the key `dim_order`.

This facilitates handing off the dim ordering to downstream visualization services.

Fixes #169 