### PR TITLE
Update dependencies and upgrade Docker base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ============================================================================
-FROM python:3.6-slim-buster
+FROM python:3.9-slim-bullseye
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ============================================================================
-FROM python:3.9-slim-bullseye
+FROM python:3.8-slim-bullseye
 
 WORKDIR /usr/src/app
 

--- a/redis_consumer/consumers/tracking_consumer.py
+++ b/redis_consumer/consumers/tracking_consumer.py
@@ -35,8 +35,8 @@ import time
 import timeit
 import uuid
 
-from skimage.external import tifffile
 import numpy as np
+import tifffile
 
 from deepcell_toolbox.processing import correct_drift
 

--- a/redis_consumer/consumers/tracking_consumer_test.py
+++ b/redis_consumer/consumers/tracking_consumer_test.py
@@ -35,7 +35,7 @@ import string
 import pytest
 
 import numpy as np
-from skimage.external import tifffile
+import tifffile
 
 from redis_consumer import consumers
 from redis_consumer import settings

--- a/redis_consumer/testing_utils.py
+++ b/redis_consumer/testing_utils.py
@@ -31,7 +31,7 @@ from __future__ import print_function
 import os
 
 import numpy as np
-from skimage.external import tifffile as tiff
+import tifffile
 
 import pytest
 import fakeredis
@@ -77,12 +77,12 @@ class DummyStorage(object):
                 base, ext = os.path.splitext(path)
                 _path = '{}{}{}'.format(base, i, ext)
                 outpath = os.path.join(dest, _path)
-                tiff.imsave(outpath, img)
+                tifffile.imsave(outpath, img)
                 paths.append(outpath)
             return utils.zip_files(paths, dest)
         img = _get_image()
         outpath = os.path.join(dest, path)
-        tiff.imsave(outpath, img)
+        tifffile.imsave(outpath, img)
         return outpath
 
     def upload(self, zip_path, subdir=None):

--- a/redis_consumer/utils.py
+++ b/redis_consumer/utils.py
@@ -39,7 +39,7 @@ import zipfile
 
 import numpy as np
 import PIL
-from skimage.external import tifffile
+import tifffile
 from tensorflow.keras.preprocessing.image import img_to_array
 
 

--- a/redis_consumer/utils_test.py
+++ b/redis_consumer/utils_test.py
@@ -37,7 +37,7 @@ import pytest
 
 import numpy as np
 from tensorflow.keras.preprocessing.image import array_to_img
-from skimage.external import tifffile as tiff
+import tifffile
 
 from redis_consumer.testing_utils import _get_image
 
@@ -48,7 +48,7 @@ def _write_image(filepath, img_w=300, img_h=300):
     imarray = _get_image(img_h, img_w, 1)
     _, ext = os.path.splitext(filepath.lower())
     if ext in {'.tif', '.tiff'}:
-        tiff.imsave(filepath, imarray[..., 0])
+        tifffile.imsave(filepath, imarray[..., 0])
     else:
         img = array_to_img(imarray, scale=False, data_format='channels_last')
         img.save(filepath)

--- a/requirements-no-deps.txt
+++ b/requirements-no-deps.txt
@@ -1,3 +1,3 @@
 # tensorflow-serving-api installs tensorflow so install
 # with --no-deps to prevent overwriting tensorflow-cpu
-tensorflow-serving-api==2.3.0
+tensorflow-serving-api~=2.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 deepcell-cpu~=0.11.0
 deepcell-toolbox~=0.10.2
 deepcell-tracking~=0.5.2
-tensorflow-cpu
+tensorflow-cpu~=2.5.2
 tifffile>=2020.9.3
 numpy>=1.16.6
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ deepcell-cpu~=0.11.0
 deepcell-toolbox~=0.10.2
 deepcell-tracking~=0.5.2
 tensorflow-cpu
-tifffile==2021.11.2
+tifffile>=2020.9.3
 numpy>=1.16.6
 
 # tensorflow-serving-apis and gRPC dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,12 +8,12 @@ numpy>=1.16.6
 
 # tensorflow-serving-apis and gRPC dependencies
 grpcio>=1.0,<2
-dict-to-protobuf==0.0.3.9
+dict-to-protobuf~=0.0.3.10
 protobuf>=3.6.0
 
 # misc storage and redis clients
 boto3>=1.9.195,<2
 google-cloud-storage>=1.16.1,<2
-python-decouple>=3.1,<4
-redis==3.4.1
-pytz==2019.1
+python-decouple~=3.1
+redis~=4.0.0
+pytz>=2021.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ deepcell-toolbox~=0.10.2
 deepcell-tracking~=0.5.2
 tensorflow-cpu
 scikit-image>=0.14.5,<0.17.0
+tifffile==2021.11.2
 numpy>=1.16.6
 
 # tensorflow-serving-apis and gRPC dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ deepcell-toolbox~=0.10.2
 deepcell-tracking~=0.5.2
 tensorflow-cpu~=2.5.2
 tifffile>=2020.9.3
+scikit-image>=0.14.5,<0.17.0
 numpy>=1.16.6
 
 # tensorflow-serving-apis and gRPC dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,5 @@ protobuf>=3.6.0
 boto3>=1.9.195,<2
 google-cloud-storage>=1.16.1,<2
 python-decouple~=3.1
-redis~=4.0.0
+redis~=3.5.3
 pytz>=2021.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ deepcell-cpu~=0.11.0
 deepcell-toolbox~=0.10.2
 deepcell-tracking~=0.5.2
 tensorflow-cpu
-scikit-image>=0.14.5,<0.17.0
 tifffile==2021.11.2
 numpy>=1.16.6
 


### PR DESCRIPTION
- Update base image to Python 3.9-slim-buster.
- Add `tifffile` to requirements and remove `scikit-image`. The project depends on `tifffile` which is no longer included in `skimage` versions that are supported by newer Python versions.
- Update a few dependencies to their latest patches.