### PR TITLE
Update assignment for channels variable in Caliban consumer

### DIFF
--- a/redis_consumer/consumers/caliban_consumer.py
+++ b/redis_consumer/consumers/caliban_consumer.py
@@ -130,7 +130,7 @@ class CalibanConsumer(TensorFlowServingConsumer):
                 'created_at': current_timestamp,
                 'updated_at': current_timestamp,
                 'url': upload_file_url,
-                'channels': hvalues.get('channels', ''),
+                'channels': '0,,',  # encodes that images are nuclear
             }
 
             # make a hash for this frame


### PR DESCRIPTION
This PR updates the `channels` value for segmentation hashes created by the Caliban consumer. The changed format in [this PR](https://github.com/vanvalenlab/kiosk-frontend/pull/182). 