### PR TITLE
Add multi-batch prediction for the segmentation and Polaris consumers

### DIFF
--- a/redis_consumer/consumers/base_consumer_test.py
+++ b/redis_consumer/consumers/base_consumer_test.py
@@ -539,7 +539,7 @@ class TestZipFileConsumer(object):
 
     def test__upload_archived_images(self, mocker, redis_client):
         N = 3
-        storage = DummyStorage(num=N)
+        storage = DummyStorage(batch=N, img_h=300, img_w=300)
         consumer = consumers.ZipFileConsumer(redis_client, storage, 'predict')
         # mocker.patch.object(consumer.storage, 'download')
         hvalues = {'input_file_name': 'test.zip', 'children': 'none'}
@@ -550,7 +550,7 @@ class TestZipFileConsumer(object):
     def test__upload_finished_children(self, mocker, redis_client):
         finished_children = ['predict:1.tiff', 'predict:2.zip', '']
         N = 3
-        storage = DummyStorage(num=N)
+        storage = DummyStorage(batch=N, img_h=300, img_w=300)
         consumer = consumers.ZipFileConsumer(redis_client, storage, 'predict')
         mocker.patch.object(consumer, '_get_output_file_name', lambda x: x)
 
@@ -595,7 +595,7 @@ class TestZipFileConsumer(object):
 
     def test__parse_failures(self, mocker, redis_client):
         N = 3
-        storage = DummyStorage(num=N)
+        storage = DummyStorage(batch=N, img_h=300, img_w=300)
 
         keys = [str(x) for x in range(4)]
         consumer = consumers.ZipFileConsumer(redis_client, storage, 'predict')
@@ -619,7 +619,7 @@ class TestZipFileConsumer(object):
         queue = 'predict'
         done = [str(i) for i in range(N)]
         failed = [str(i) for i in range(N + 1, N * 2)]
-        storage = DummyStorage(num=N)
+        storage = DummyStorage(batch=N, img_h=300, img_w=300)
         consumer = consumers.ZipFileConsumer(redis_client, storage, queue)
 
         redis_hash = 'some job hash'
@@ -642,7 +642,7 @@ class TestZipFileConsumer(object):
 
     def test__consume(self, mocker, redis_client):
         N = 3
-        storage = DummyStorage(num=N)
+        storage = DummyStorage(batch=N, img_h=300, img_w=300)
         children = list('abcdefg')
         queue = 'q'
         test_hash = 0

--- a/redis_consumer/consumers/caliban_consumer.py
+++ b/redis_consumer/consumers/caliban_consumer.py
@@ -116,7 +116,7 @@ class CalibanConsumer(TensorFlowServingConsumer):
                 segment_fname = '{}-{}-tracking-frame-{}.tif'.format(
                     uid, hvalues.get('original_name'), i)
                 segment_local_path = os.path.join(tempdir, segment_fname)
-                tifffile.imsave(segment_local_path, img)
+                tifffile.imsave(segment_local_path, np.squeeze(img))
                 upload_file_name, upload_file_url = self.storage.upload(
                     segment_local_path)
 
@@ -130,7 +130,8 @@ class CalibanConsumer(TensorFlowServingConsumer):
                 'created_at': current_timestamp,
                 'updated_at': current_timestamp,
                 'url': upload_file_url,
-                'channels': '0,,',  # encodes that images are nuclear
+                'channels': '0,,',  # encodes that images are nuclear,
+                'dimension_order': 'XY'
             }
 
             # make a hash for this frame

--- a/redis_consumer/consumers/caliban_consumer.py
+++ b/redis_consumer/consumers/caliban_consumer.py
@@ -86,10 +86,8 @@ class CalibanConsumer(TensorFlowServingConsumer):
             raise ValueError('_load_data takes in only .tiff, .trk, or .trks')
 
         # push a key per frame and let ImageFileConsumers segment
-        raw = utils.get_image(os.path.join(subdir, fname))
+        tiff_stack = utils.get_image(os.path.join(subdir, fname))
 
-        # remove the last dimensions added by `get_image`
-        tiff_stack = np.squeeze(raw, -1)
         if len(tiff_stack.shape) != 3:
             raise ValueError('This tiff file has shape {}, which is not 3 '
                              'dimensions. Tracking can only be done on images '

--- a/redis_consumer/consumers/polaris_consumer.py
+++ b/redis_consumer/consumers/polaris_consumer.py
@@ -101,10 +101,14 @@ class PolarisConsumer(TensorFlowServingConsumer):
         data.
         """
         hvals = self.redis.hgetall(redis_hash)
-        raw = utils.get_image(os.path.join(subdir, fname))
+        tiff_stack = utils.get_image(os.path.join(subdir, fname))
 
-        # remove the last dimensions added by `get_image`
-        tiff_stack = np.squeeze(raw)
+        channels = hvals.get('channels').split(',')  # ex: channels = ['0','1','2']
+        filled_channels = [c for c in channels if c]
+        if len(filled_channels) > np.shape(tiff_stack)[-1]:
+            raise ValueError('Input image has {} channels but {} channels were specified '
+                             'for segmentation'.format(np.shape(tiff_stack)[-1],
+                                                       len(filled_channels)))
 
         self.logger.debug('Got tiffstack shape %s.', tiff_stack.shape)
 

--- a/redis_consumer/consumers/polaris_consumer.py
+++ b/redis_consumer/consumers/polaris_consumer.py
@@ -224,9 +224,6 @@ class PolarisConsumer(TensorFlowServingConsumer):
         if segmentation_type == 'cell culture':
             for key in segmentation_dict.keys():
                 labeled_im = np.array(segmentation_dict[key])
-                # labeled_im = np.squeeze(labeled_im, -1)  # c,x,y,1 to c,x,y
-                # labeled_im = np.moveaxis(labeled_im, 0, 2)  # c,x,y to x,y,c
-                # segmentation_results.append(labeled_im) # to b,x,y,c
                 labeled_im = np.swapaxes(labeled_im, 0, -1)  # c,x,y,b to b,x,y,c
                 segmentation_results.extend(labeled_im)
 

--- a/redis_consumer/consumers/polaris_consumer.py
+++ b/redis_consumer/consumers/polaris_consumer.py
@@ -78,7 +78,8 @@ class PolarisConsumer(TensorFlowServingConsumer):
             'updated_at': current_timestamp,
             'url': upload_file_url,
             'channels': channels,
-            'scale': settings.POLARIS_SCALE}  # scaling not supported for spots model
+            'scale': settings.POLARIS_SCALE,  # scaling not supported for spots model
+            'dimension_order': 'BXY'}
 
         # make a hash for this frame
         image_hash = '{prefix}:{file}:{hash}'.format(

--- a/redis_consumer/consumers/polaris_consumer_test.py
+++ b/redis_consumer/consumers/polaris_consumer_test.py
@@ -75,7 +75,7 @@ class TestPolarisConsumer(object):
 
         fname = 'file.tiff'
         filepath = os.path.join(tmpdir, fname)
-        input_size = (1, 32, 32, 1)
+        input_size = (1, 32, 32, 3)
 
         # test successful workflow
         def hget_successful_status(*_):

--- a/redis_consumer/consumers/segmentation_consumer.py
+++ b/redis_consumer/consumers/segmentation_consumer.py
@@ -157,6 +157,8 @@ class SegmentationConsumer(TensorFlowServingConsumer):
         # Load input image
         fname = hvals.get('input_file_name')
         image = self.download_image(fname)
+        # Squeeze out dimension added by get_image
+        image = np.squeeze(image, axis=-1)
         dim_order = hvals.get('dimension_order')
 
         # Modify image dimensions to be BXYC

--- a/redis_consumer/consumers/segmentation_consumer.py
+++ b/redis_consumer/consumers/segmentation_consumer.py
@@ -163,7 +163,7 @@ class SegmentationConsumer(TensorFlowServingConsumer):
 
         channels = hvals.get('channels').split(',')  # ex: channels = ['0','1','2']
         filled_channels = [c for c in channels if c]
-        if len(filled_channels) != np.shape(image)[3]:
+        if len(filled_channels) > np.shape(image)[3]:
             raise ValueError('Input image has {} channels but {} channels were specified '
                              'for segmentation'.format(np.shape(image)[3], len(filled_channels)))
 

--- a/redis_consumer/consumers/segmentation_consumer.py
+++ b/redis_consumer/consumers/segmentation_consumer.py
@@ -158,7 +158,7 @@ class SegmentationConsumer(TensorFlowServingConsumer):
         fname = hvals.get('input_file_name')
         image = self.download_image(fname)
         # Squeeze out dimension added by get_image
-        image = np.squeeze(image, axis=-1)
+        # image = np.squeeze(image, axis=-1)
         dim_order = hvals.get('dimension_order')
 
         # Modify image dimensions to be BXYC
@@ -202,6 +202,10 @@ class SegmentationConsumer(TensorFlowServingConsumer):
                                            image_mpp=scale * app.model_mpp)
 
                 results.extend(pred_results)
+
+        self.logger.debug('Results shape before: {}'.format(np.shape(results)))
+        results = np.swapaxes(np.array(results), 0, 1)  # c,b,x,y,1 to b,c,x,y,1
+        self.logger.debug('Results shape before: {}'.format(np.shape(results)))
 
         # Save the post-processed results to a file
         _ = timeit.default_timer()

--- a/redis_consumer/consumers/segmentation_consumer.py
+++ b/redis_consumer/consumers/segmentation_consumer.py
@@ -91,7 +91,7 @@ class SegmentationConsumer(TensorFlowServingConsumer):
 
         if len(np.shape(image)) != len(dim_order):
             raise ValueError('Input dimension order was {} but input '
-                             'image has {} dimensions'.format(dim_order, len(np.shape(image))))
+                             'image has shape {}'.format(dim_order, np.shape(image)))
 
         if dim_order == 'XYB':
             image = np.moveaxis(image, -1, 0)

--- a/redis_consumer/consumers/segmentation_consumer.py
+++ b/redis_consumer/consumers/segmentation_consumer.py
@@ -93,28 +93,19 @@ class SegmentationConsumer(TensorFlowServingConsumer):
             raise ValueError('Input dimension order was {} but input '
                              'image has {} dimensions'.format(dim_order, len(np.shape(image))))
 
-        if dim_order == 'BXYC':
-            return(image)
-
-        elif dim_order == 'XY':
-            return(np.expand_dims(image, axis=[0, -1]))
-
-        elif dim_order == 'BXY':
-            return(np.expand_dims(image, axis=-1))
-
-        elif dim_order == 'XYC':
-            return(np.expand_dims(image, axis=0))
-
-        elif dim_order == 'XYB':
+        if dim_order == 'XYB':
             image = np.moveaxis(image, -1, 0)
-            return(np.expand_dims(image, axis=-1))
-
         elif dim_order == 'CXY':
             image = np.moveaxis(image, 0, -1)
-            return(np.expand_dims(image, axis=0))
-
         elif dim_order == 'CXYB':
-            return(np.swapaxes(image, 0, -1))
+            image = np.swapaxes(image, 0, -1)
+
+        if 'B' not in dim_order:
+            image = np.expand_dims(image, axis=0)
+        if 'C' not in dim_order:
+            image = np.expand_dims(image, axis=-1)
+
+        return(image)
 
     def save_output(self, image, save_name):
         """Save output images into a zip file and upload it."""

--- a/redis_consumer/consumers/segmentation_consumer.py
+++ b/redis_consumer/consumers/segmentation_consumer.py
@@ -69,7 +69,7 @@ class SegmentationConsumer(TensorFlowServingConsumer):
         return int(detected_label)
 
     def get_image_label(self, label, image, redis_hash):
-        """ DEPRACATED -- Calculate label of image."""
+        """ DEPRECATED -- Calculate label of image."""
         if not label:
             # Detect scale of image (Default to 1)
             label = self.detect_label(image)

--- a/redis_consumer/consumers/segmentation_consumer.py
+++ b/redis_consumer/consumers/segmentation_consumer.py
@@ -154,8 +154,6 @@ class SegmentationConsumer(TensorFlowServingConsumer):
         # Load input image
         fname = hvals.get('input_file_name')
         image = self.download_image(fname)
-        # Squeeze out dimension added by get_image
-        # image = np.squeeze(image, axis=-1)
         dim_order = hvals.get('dimension_order')
 
         # Modify image dimensions to be BXYC

--- a/redis_consumer/consumers/segmentation_consumer.py
+++ b/redis_consumer/consumers/segmentation_consumer.py
@@ -86,6 +86,10 @@ class SegmentationConsumer(TensorFlowServingConsumer):
     def image_dimensions_to_bxyc(self, dim_order, image):
         """Modifies image dimensions to be BXYC."""
 
+        if len(np.shape(image)) != len(dim_order):
+            raise ValueError('Input dimension order was {} but input '
+                             'image has {} dimensions'.format(dim_order, len(np.shape(image))))
+
         if dim_order == 'BXYC':
             return(image)
 

--- a/redis_consumer/consumers/segmentation_consumer.py
+++ b/redis_consumer/consumers/segmentation_consumer.py
@@ -114,9 +114,6 @@ class SegmentationConsumer(TensorFlowServingConsumer):
             subdir = os.path.dirname(save_name.replace(tempdir, ''))
             name = os.path.splitext(os.path.basename(save_name))[0]
 
-            if not isinstance(image, list):
-                image = [image]
-
             outpaths = []
             for i, img in enumerate(image):
                 outpaths.extend(utils.save_numpy_array(
@@ -201,11 +198,10 @@ class SegmentationConsumer(TensorFlowServingConsumer):
                 pred_results = app.predict(slice_image, batch_size=batch_size,
                                            image_mpp=scale * app.model_mpp)
 
-                results.extend(pred_results)
+                results.append(pred_results)
 
-        self.logger.debug('Results shape before: {}'.format(np.shape(results)))
-        results = np.swapaxes(np.array(results), 0, 1)  # c,b,x,y,1 to b,c,x,y,1
-        self.logger.debug('Results shape before: {}'.format(np.shape(results)))
+        results = np.squeeze(np.array(results), axis=-1)  # c,b,x,y,1 to c,b,x,y
+        results = np.moveaxis(results, 0, -1)  # c,b,x,y to b,x,y,c
 
         # Save the post-processed results to a file
         _ = timeit.default_timer()

--- a/redis_consumer/consumers/segmentation_consumer_test.py
+++ b/redis_consumer/consumers/segmentation_consumer_test.py
@@ -132,7 +132,7 @@ class TestSegmentationConsumer(object):
             pytest.param((1, 32, 32, 1), '0,,', 'BXYC', id='bxyc-nuc'),
             pytest.param((1, 32, 32, 1), ',0,', 'BXYC', id='bxyc-cyto'),
             pytest.param((1, 32, 32, 2), '0,1,', 'BXYC', id='bxyc-nuc-cyto'),
-            pytest.param((1, 32, 32, 2), '1,0,', 'BXYC', id='bxyc-nuc-cyto'),
+            pytest.param((1, 32, 32, 2), '1,0,', 'BXYC', id='bxyc-cyto-nuc'),
             pytest.param((2, 32, 32, 2), '0,1,', 'BXYC', id='bxyc-nuc-cyto-multibatch'),
             pytest.param((2, 32, 32, 1), '0,1,', 'CXYB', id='cxyb-nuc-cyto')
         ]
@@ -151,7 +151,7 @@ class TestSegmentationConsumer(object):
                       'channels': channels,
                       'dimension_order': dim_order}
 
-        output_shape = tuple(i for i in shape if i is not None)
+        output_shape = (1, shape[1], shape[2], 1)
 
         mock_app = Bunch(
             predict=lambda *x, **y: np.random.randint(1, 5, size=output_shape),

--- a/redis_consumer/consumers/segmentation_consumer_test.py
+++ b/redis_consumer/consumers/segmentation_consumer_test.py
@@ -134,7 +134,8 @@ class TestSegmentationConsumer(object):
         consumer = consumers.SegmentationConsumer(redis_client, storage, queue)
 
         empty_data = {'input_file_name': 'file.tiff',
-                      'channels': channels}
+                      'channels': channels,
+                      'dimension_order': 'BXYC'}
 
         output_shape = shape
 

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -55,7 +55,8 @@ REDIS_PORT = config('REDIS_PORT', default=6379, cast=int)
 TF_HOST = config('TF_HOST', default='tf-serving')
 TF_PORT = config('TF_PORT', default=8500, cast=int)
 # maximum batch allowed by TensorFlow Serving
-TF_MAX_BATCH_SIZE = config('TF_MAX_BATCH_SIZE', default=128, cast=int)
+# must be manually matched to the helmfile for the TF-serving pod
+TF_MAX_BATCH_SIZE = config('TF_MAX_BATCH_SIZE', default=64, cast=int)
 # minimum expected model size, dynamically change batches proportionately.
 TF_MIN_MODEL_SIZE = config('TF_MIN_MODEL_SIZE', default=128, cast=int)
 

--- a/redis_consumer/utils.py
+++ b/redis_consumer/utils.py
@@ -101,7 +101,7 @@ def get_image(filepath):
     if os.path.splitext(filepath)[-1].lower() in {'.tif', '.tiff'}:
         img = tifffile.TiffFile(filepath).asarray()
         # tiff files should not have a channel dim
-        img = np.expand_dims(img, axis=-1)
+        # img = np.expand_dims(img, axis=-1)
     else:
         img = img_to_array(PIL.Image.open(filepath))
 

--- a/redis_consumer/utils.py
+++ b/redis_consumer/utils.py
@@ -100,8 +100,6 @@ def get_image(filepath):
     logger.debug('Loading %s into numpy array', filepath)
     if os.path.splitext(filepath)[-1].lower() in {'.tif', '.tiff'}:
         img = tifffile.TiffFile(filepath).asarray()
-        # tiff files should not have a channel dim
-        # img = np.expand_dims(img, axis=-1)
     else:
         img = img_to_array(PIL.Image.open(filepath))
 

--- a/redis_consumer/utils_test.py
+++ b/redis_consumer/utils_test.py
@@ -120,7 +120,7 @@ def test_get_image(tmpdir):
     _write_image(test_img_path, 300, 300)
     test_img = utils.get_image(test_img_path)
     print(test_img.shape)
-    np.testing.assert_equal(test_img.shape, (300, 300, 1))
+    np.testing.assert_equal(test_img.shape, (300, 300))
     # test png files
     test_img_path = os.path.join(tmpdir, 'feature_0.png')
     _write_image(test_img_path, 400, 400)


### PR DESCRIPTION
This PR adds support for multi-batch images for the segmentation and Polaris consumers. The segmentation consumer receives a variable `dimension_order` from the frontend (see [this PR](https://github.com/vanvalenlab/kiosk-frontend/pull/193)). This variable has been added to the data generated by the Polaris consumer for segmentation jobs.

We have also added more comprehensive testing of the segmentation consumer for input images of different dimension orders. This involved changes to the `DummyStorage` object to allow the dimensions of the images it generates to be specified. 

We have removed a line from the `get_image` utils function that expands the dimensions of loaded TIFF files by default, because this behavior complicated the handling of images with dimensions BXYC or CXYB. This change had little impact on the other functions that call `get_image`,  because this channel was often squeezed out immediately after loading. 