### PR TITLE
Cache pip environment for Github actions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,13 +25,10 @@ jobs:
     - name: Cache pip
       uses: actions/cache@v2
       with:
-        # This path is specific to Ubuntu
-        path: ~/.cache/pip
-        # Look to see if there is a cache hit for the corresponding requirements file
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+        path: ${{ env.pythonLocation }}
+        key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
         restore-keys: |
-          ${{ runner.os }}-pip-
-          ${{ runner.os }}-
+          ${{ env.pythonLocation }}-
 
     - name: Install Dependencies
       run: |


### PR DESCRIPTION
This PR introduces a change to cache the pip environment created to run the test Github action. With this change the tests run in under 2 minutes instead of 7-8 minutes.