### PR TITLE
Expose GRPC model output names

### DIFF
--- a/redis_consumer/grpc_clients.py
+++ b/redis_consumer/grpc_clients.py
@@ -333,7 +333,8 @@ class GrpcModelWrapper(object):
 
         self._client.logger.debug('Predicting...')
         prediction = self._client.predict(req_data, settings.GRPC_TIMEOUT)
-        results = [prediction[k] for k in sorted(prediction.keys())]
+        self.output_names = prediction.keys()
+        results = [prediction[k] for k in sorted(self.output_names)]
 
         self._client.logger.debug('Got prediction results of shape %s in %s s.',
                                   [r.shape for r in results],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,12 @@
 # deepcell packages
 deepcell-cpu~=0.11.0
-# deepcell-spots~=0.3.0
+deepcell-spots~=0.2.1
 deepcell-toolbox~=0.10.3
 deepcell-tracking~=0.5.2
 tensorflow-cpu~=2.5.2
 tifffile>=2020.9.3
 numpy>=1.16.6
 matplotlib>=2.1.1
-
-git+https://github.com/vanvalenlab/deepcell-spots@5321818970a61473ccf03055c504a8a3061c296e
 
 # tensorflow-serving-apis and gRPC dependencies
 grpcio>=1.0,<2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,14 @@
 # deepcell packages
 deepcell-cpu~=0.11.0
-deepcell-spots~=0.2.0
+# deepcell-spots~=0.3.0
 deepcell-toolbox~=0.10.3
 deepcell-tracking~=0.5.2
 tensorflow-cpu~=2.5.2
 tifffile>=2020.9.3
 numpy>=1.16.6
 matplotlib>=2.1.1
+
+git+https://github.com/vanvalenlab/deepcell-spots@5321818970a61473ccf03055c504a8a3061c296e
 
 # tensorflow-serving-apis and gRPC dependencies
 grpcio>=1.0,<2


### PR DESCRIPTION
This PR makes changes to expose the output names of the GRPC-wrapped model. These changes allow the outputs of the TF-served model to be formatted into a dictionary. They are related to [this spots PR](https://github.com/vanvalenlab/deepcell-spots/pull/22).