### PR TITLE
Update to Tensorflow 2.8

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -92,9 +92,9 @@ EXPIRE_TIME = config('EXPIRE_TIME', default=3600, cast=int)
 METADATA_EXPIRE_TIME = config('METADATA_EXPIRE_TIME', default=30, cast=int)
 
 # Tracking settings
-TRACKING_MODEL = config('TRACKING_MODEL', default='TrackingModelInf:4', cast=str)
+TRACKING_MODEL = config('TRACKING_MODEL', default='NuclearTrackingInf:6', cast=str)
 CALIBAN_MODEL = config('CALIBAN_MODEL', default=TRACKING_MODEL, cast=str)
-NEIGHBORHOOD_ENCODER = config('NEIGHBORHOOD_ENCODER', default='TrackingModelNE:2', cast=str)
+NEIGHBORHOOD_ENCODER = config('NEIGHBORHOOD_ENCODER', default='NuclearTrackingNE:6', cast=str)
 
 # tracking.cell_tracker settings TODO: can we extract from model_metadata?
 MAX_DISTANCE = config('MAX_DISTANCE', default=50, cast=int)
@@ -115,7 +115,7 @@ LABEL_DETECT_ENABLED = config('LABEL_DETECT_ENABLED', default=False, cast=bool)
 
 # Mesmer model Settings
 # deprecated model name, use MESMER_MODEL instead.
-MULTIPLEX_MODEL = config('MULTIPLEX_MODEL', default='MultiplexSegmentation:5', cast=str)
+MULTIPLEX_MODEL = config('MULTIPLEX_MODEL', default='MultiplexSegmentation:9', cast=str)
 MESMER_MODEL = config('MESMER_MODEL', default=MULTIPLEX_MODEL, cast=str)
 MESMER_COMPARTMENT = config('MESMER_COMPARTMENT', default='whole-cell')
 
@@ -127,8 +127,8 @@ POLARIS_SCALE = config('POLARIS_SCALE', default=0.38, cast=float)
 
 # Set default models based on label type
 MODEL_CHOICES = {
-    0: config('NUCLEAR_MODEL', default='NuclearSegmentation:5', cast=str),
-    1: config('CYTOPLASM_MODEL', default='CytoplasmSegmentation:4', cast=str),
+    0: config('NUCLEAR_MODEL', default='NuclearSegmentation:6', cast=str),
+    1: config('CYTOPLASM_MODEL', default='CytoplasmSegmentation:5', cast=str),
     2: config('PHASE_MODEL', default='PhaseCytoSegmentation:0', cast=str)
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # deepcell packages
 deepcell-cpu~=0.12.0
-deepcell-spots~=0.3.0
+deepcell-spots~=0.3.1
 deepcell-toolbox~=0.11.2
 deepcell-tracking~=0.5.7
 tensorflow-cpu~=2.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 # deepcell packages
-deepcell-cpu~=0.11.0
-deepcell-spots~=0.2.1
-deepcell-toolbox~=0.10.3
-deepcell-tracking~=0.5.2
-tensorflow-cpu~=2.5.2
+deepcell-cpu~=0.12.0
+deepcell-spots~=0.3.0
+deepcell-toolbox~=0.11.2
+deepcell-tracking~=0.5.7
+tensorflow-cpu~=2.8.0
 tifffile>=2020.9.3
 imagecodecs
 numpy>=1.16.6


### PR DESCRIPTION
This PR updates the TF version run by the kiosk, including the following changes:

- Bumping the required TF version to 2.8
- Bumping the required version of deepcell packages to those running TF 2.8
- Dropping support for Python 3.6 and adding Python 3.9