### PR TITLE
Save and expose sorted output_names

### DIFF
--- a/redis_consumer/grpc_clients.py
+++ b/redis_consumer/grpc_clients.py
@@ -333,8 +333,8 @@ class GrpcModelWrapper(object):
 
         self._client.logger.debug('Predicting...')
         prediction = self._client.predict(req_data, settings.GRPC_TIMEOUT)
-        self.output_names = prediction.keys()
-        results = [prediction[k] for k in sorted(self.output_names)]
+        self.output_names = sorted(list(prediction.keys()))
+        results = [prediction[k] for k in self.output_names]
 
         self._client.logger.debug('Got prediction results of shape %s in %s s.',
                                   [r.shape for r in results],


### PR DESCRIPTION
This PR fixes [this issue](https://github.com/vanvalenlab/kiosk-console/issues/458). The GRPC client returns a dictionary with keys corresponding to the output names. These names were previously sorted but the sorted keys were not saved. Therefore, when these keys were exposed and used, sometimes they were in the wrong order. 