### PR TITLE
Bump deepcell version and add tracking parameters

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,7 +40,7 @@ jobs:
 
     - name: PyTest
       run: |
-        pytest --cov redis_consumer --pep8
+        pytest --cov redis_consumer
 
     - name: Coveralls
       if: env.COVERALLS_REPO_TOKEN != null

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2
@@ -36,6 +36,7 @@ jobs:
         pip install -r requirements.txt
         pip install --no-deps -r requirements-no-deps.txt
         pip install -r requirements-test.txt
+        pip list
 
     - name: PyTest
       run: |

--- a/redis_consumer/consumers/caliban_consumer.py
+++ b/redis_consumer/consumers/caliban_consumer.py
@@ -240,7 +240,7 @@ class CalibanConsumer(TensorFlowServingConsumer):
                                 death=settings.DEATH,
                                 division=settings.DIVISION,
                                 track_length=settings.TRACK_LENGTH,
-                                embedding_axis=0,
+                                embedding_axis=1,  # This must be 1, not 0 like in the locally used application
                                 crop_mode=settings.CROP_MODE,
                                 norm=settings.CALIBAN_NORM)
 

--- a/redis_consumer/consumers/caliban_consumer.py
+++ b/redis_consumer/consumers/caliban_consumer.py
@@ -234,11 +234,15 @@ class CalibanConsumer(TensorFlowServingConsumer):
         # Send data to the model
         app = self.get_grpc_app(settings.CALIBAN_MODEL, CellTracking,
                                 neighborhood_encoder=neighborhood_encoder,
+                                distance_threshold=settings.MAX_DISTANCE,
+                                appearance_dim=settings.APPEARANCE_DIM,
                                 birth=settings.BIRTH,
                                 death=settings.DEATH,
                                 division=settings.DIVISION,
                                 track_length=settings.TRACK_LENGTH,
-                                embedding_axis=1)
+                                embedding_axis=0,
+                                crop_mode=settings.CROP_MODE,
+                                norm=settings.CALIBAN_NORM)
 
         self.logger.debug('Tracking...')
         self.update_key(redis_hash, {'status': 'predicting'})

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -97,11 +97,14 @@ CALIBAN_MODEL = config('CALIBAN_MODEL', default=TRACKING_MODEL, cast=str)
 NEIGHBORHOOD_ENCODER = config('NEIGHBORHOOD_ENCODER', default='NuclearTrackingNE:6', cast=str)
 
 # tracking.cell_tracker settings TODO: can we extract from model_metadata?
-MAX_DISTANCE = config('MAX_DISTANCE', default=50, cast=int)
+MAX_DISTANCE = config('MAX_DISTANCE', default=50, cast=int) # distance_threshold in application
 TRACK_LENGTH = config('TRACK_LENGTH', default=8, cast=int)
 DIVISION = config('DIVISION', default=0.9, cast=float)
 BIRTH = config('BIRTH', default=0.99, cast=float)
 DEATH = config('DEATH', default=0.99, cast=float)
+APPEARANCE_DIM = config('APPEARANCE_DIM', default=32, cast=int)
+CROP_MODE = config('CROP_MODE', dafault='resize', cast=str)
+CALIBAN_NORM = config('CALIBAN_NORM', default=True, cast=bool)
 
 # Scale detection settings
 SCALE_DETECT_MODEL = config('SCALE_DETECT_MODEL', default='ScaleDetection:1')

--- a/redis_consumer/settings.py
+++ b/redis_consumer/settings.py
@@ -103,7 +103,7 @@ DIVISION = config('DIVISION', default=0.9, cast=float)
 BIRTH = config('BIRTH', default=0.99, cast=float)
 DEATH = config('DEATH', default=0.99, cast=float)
 APPEARANCE_DIM = config('APPEARANCE_DIM', default=32, cast=int)
-CROP_MODE = config('CROP_MODE', dafault='resize', cast=str)
+CROP_MODE = config('CROP_MODE', default='resize', cast=str)
 CALIBAN_NORM = config('CALIBAN_NORM', default=True, cast=bool)
 
 # Scale detection settings

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,6 @@
-pytest<6
+pytest
 pytest-cov
 pytest-mock
-pytest-pep8
 fakeredis
 six>=1.12
 coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # deepcell packages
-deepcell-cpu~=0.12.5
+deepcell-cpu~=0.12.6
 deepcell-spots~=0.3.1
 deepcell-toolbox~=0.12.0
 deepcell-tracking~=0.6.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # deepcell packages
-deepcell-cpu~=0.12.0
+deepcell-cpu~=0.12.5
 deepcell-spots~=0.3.1
-deepcell-toolbox~=0.11.2
-deepcell-tracking~=0.5.7
+deepcell-toolbox~=0.12.0
+deepcell-tracking~=0.6.4
 tensorflow-cpu~=2.8.0
 tifffile>=2020.9.3
 imagecodecs


### PR DESCRIPTION
This PR preps the consumers for the tracking paper. It bumps up the versions of deepcell packages and adds additional tracking parameters that have been recently exposed.

This update has been tested in a test deployment of the kiosk, but I would like to hold off on merging it until we have resolved https://github.com/vanvalenlab/deepcell-tf/issues/665 and released a new version of deepcell with the fix.